### PR TITLE
Make activation step optional

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors:      rektification, npagazani
 Tags:              woocommerce, telegram, subscriptions
 Requires at least: 6.0
 Tested up to:      6.8.2
-Stable tag:        1.3.0
+Stable tag:        1.4.0
 License:           GPL-2.0-or-later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -66,6 +66,9 @@ It also sets a webhook to handle communication between your WooCommerce store an
 
 
 == Changelog ==
+
+= 1.4.0 =
+* Made the activation step optional.
 
 = 1.3.0 =
 * Improved private group compatibility. Now supports private groups and supergroups.

--- a/README.txt
+++ b/README.txt
@@ -2,7 +2,7 @@
 Contributors:      rektification, npagazani
 Tags:              woocommerce, telegram, subscriptions
 Requires at least: 6.0
-Tested up to:      6.8.2
+Tested up to:      6.8.3
 Stable tag:        1.4.0
 License:           GPL-2.0-or-later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
@@ -14,26 +14,28 @@ Automatically manage Telegram private channel and group subscribers via WooComme
 Automatically manage Telegram private channel and group subscribers via WooCommerce.
 
 With Subscriber Manager Lite for Telegram you can sell access to your private Telegram channels and groups via a Simple product in
-WooCommerce. Following a successful checkout, users will be able to link to and submit an activation code in your chat bot.
-This automatically generates an invite link for the user to click on. The invite link is validated in the back-end, and the user is automatically granted access.
+WooCommerce. Following a successful checkout, users will be provided with an automatically generated one-time use invite link for channel or group access.
+The invite link is validated in the back-end, and the user is automatically granted access. No admin interaction is required.
 
 == Features ==
 
 * Grant access to a single private Telegram channel or group after successful WooCommerce checkout.
 * You only need to enter your bot token and URL to get started.
 * Semi-automatic channel or group ID retrieval.
-* Telegram user ID's automatically retrieved and validated during activation.
+* Telegram user ID's automatically retrieved and validated during activation or join request approval.
 * Set channel or group access to any Simple product in WooCommerce.
+* Choose between two different post-checkout flows (Activation via bot, or direct invite link generation).
+* Allow or block external or manual Telgram invites.
 * Secure webhook validation.
-* Works with WooCommerce HPOS
+* Works with WooCommerce HPOS.
 
-Note, in the Lite version members are not automatically removed. They can be removed manually from within Telegram.
+Note, in the Lite version members are not automatically removed from channels or groups. They can be removed manually from within Telegram.
 
 == Pro version ==
 
 * Control access to **unlimited** Telegram private channels or groups.
 * Control access to multiple channels or groups per product. 
-* Use with both Simple and Simple Subscription products in WooCommerce.
+* Use with both **Simple** and **Simple Subscription** products in WooCommerce.
 * Automatically removes members when their subscriptions expire.
 * Members won't be removed if they have multiple subscriptions and at least one is still active.
 * Works best with WooCommerce Subscriptions. Other subscription plugins support coming soon.
@@ -46,7 +48,7 @@ Note, in the Lite version members are not automatically removed. They can be rem
 Use the standard WordPress plugins installation page and install or upload the plugin.
 
 After plugin activation plugin settings are in **Settings > Telegram Subscriber Manager** in the wp-admin dashboard.
-Individual product settings are in the **Product data** settings in the **Telegram Channels** tab (available for Simple and Simple Subscription products only).
+Individual product settings are in the **Product data** settings in the **Telegram Channels** tab (available for **Simple** and **Simple Subscription** products only).
 
 
 == External services ==
@@ -68,7 +70,13 @@ It also sets a webhook to handle communication between your WooCommerce store an
 == Changelog ==
 
 = 1.4.0 =
-* Made the activation step optional.
+* New: Make the activation step optional.
+* Update: Emails formatting and wording.
+* Update: Additional logging throughout.
+* Fix: Several text updates to remove specific references to "Channels" as the plugin now supports groups.
+* Fix: Internal order search functions to improve validation.
+* Fix: Add contextual bot allowed_updates depending on checkout flow to prevent overwhelming site with webhook calls which might occur in large or busy groups.
+* Fix: Contextual switching of available product setting options when editing products.
 
 = 1.3.0 =
 * Improved private group compatibility. Now supports private groups and supergroups.

--- a/assets/js/wctlgm-subscriber-manager-lite.js
+++ b/assets/js/wctlgm-subscriber-manager-lite.js
@@ -12,7 +12,7 @@ jQuery(document).ready(function($) {
 			success: function(response) {
 				if (response.success) {
 					$('input[name="wctlgm_channels[0][id]"]').val(response.data.channel_id);
-					alert('Channel ID fetched successfully.');
+					alert('ID fetched successfully.');
 				} else {
 					alert(response.data.message);
 				}

--- a/assets/js/wctlgm-subscriber-manager-lite.js
+++ b/assets/js/wctlgm-subscriber-manager-lite.js
@@ -25,6 +25,11 @@ jQuery(document).ready(function($) {
 			alert('Please save a valid bot token first.');
 			return;
 		}
+
+		var $button = $(this);
+		var originalText = $button.text();
+		$button.prop('disabled', true).text('Setting Webhook...');
+
 		// AJAX call to set webhook
 		$.ajax({
 			url: ajaxurl,
@@ -34,6 +39,7 @@ jQuery(document).ready(function($) {
 			},
 			success: function(response) {
 				if (response.success) {
+					$('#wctlgm-webhook-notice').fadeOut();
 					alert(response.data.message);
 				} else {
 					alert('Error: ' + response.data.message);
@@ -41,7 +47,28 @@ jQuery(document).ready(function($) {
 			},
 			error: function() {
 				alert('Failed to set webhook.');
+			},
+			complete: function() {
+				$button.prop('disabled', false).text(originalText);
 			}
 		});
 	});
+
+	// Handle notification dismissal
+	$(document).on('click', '#wctlgm-webhook-notice .notice-dismiss', function() {
+		// Optional: Send AJAX request to clear the transient
+		$.ajax({
+			url: ajaxurl,
+			method: 'POST',
+			data: {
+				action: 'wctlgm_dismiss_webhook_notice',
+			}
+		});
+	});
+
+	// Highlight the Set Webhook button when notification is present
+	if ($('#wctlgm-webhook-notice').length > 0) {
+		$('#wctlgm_set_webhook_button').addClass('button-primary').removeClass('button-secondary');
+	}
+	
 });

--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "freemius/wordpress-sdk",
-            "version": "2.12.0",
+            "version": "2.12.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Freemius/wordpress-sdk.git",
-                "reference": "db6f35a2b3d318a53330409dbeab49156ee76dd8"
+                "reference": "241fbfc91151f85d8ebeb75343caf29bda1d3208"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Freemius/wordpress-sdk/zipball/db6f35a2b3d318a53330409dbeab49156ee76dd8",
-                "reference": "db6f35a2b3d318a53330409dbeab49156ee76dd8",
+                "url": "https://api.github.com/repos/Freemius/wordpress-sdk/zipball/241fbfc91151f85d8ebeb75343caf29bda1d3208",
+                "reference": "241fbfc91151f85d8ebeb75343caf29bda1d3208",
                 "shasum": ""
             },
             "require": {
@@ -55,9 +55,9 @@
             ],
             "support": {
                 "issues": "https://github.com/Freemius/wordpress-sdk/issues",
-                "source": "https://github.com/Freemius/wordpress-sdk/tree/2.12.0"
+                "source": "https://github.com/Freemius/wordpress-sdk/tree/2.12.2"
             },
-            "time": "2025-05-11T07:07:09+00:00"
+            "time": "2025-09-15T14:36:55+00:00"
         }
     ],
     "packages-dev": [],

--- a/includes/class-subscriber-manager-lite-wctlgm-api-handler.php
+++ b/includes/class-subscriber-manager-lite-wctlgm-api-handler.php
@@ -141,6 +141,7 @@ class Subscriber_Manager_Lite_WCTLGM_API_Handler {
 		);
 
 		if ( is_wp_error( $response ) ) {
+			$this->logger->error( __( 'Failed to send message. WordPress error: ', 'wctlgm-subscriber-manager-lite' ) . $response->get_error_message() );
 			return $response;
 		}
 	}
@@ -165,6 +166,7 @@ class Subscriber_Manager_Lite_WCTLGM_API_Handler {
 		);
 
 		if ( is_wp_error( $response ) ) {
+			$this->logger->error( __( 'Failed to generate invite link. WordPress error: ', 'wctlgm-subscriber-manager-lite' ) . $response->get_error_message() );
 			return $response;
 		}
 
@@ -174,6 +176,7 @@ class Subscriber_Manager_Lite_WCTLGM_API_Handler {
 		if ( isset( $data['ok'] ) && $data['ok'] ) {
 			return $data['result']['invite_link'];
 		}
+		$this->logger->error( __( 'Failed to generate invite link. Telegram API error: ', 'wctlgm-subscriber-manager-lite' ) . $body );
 
 		return new \WP_Error( 'api_error', isset( $data['description'] ) ? $data['description'] : 'Failed to create invite link.' );
 	}
@@ -196,6 +199,7 @@ class Subscriber_Manager_Lite_WCTLGM_API_Handler {
 		);
 
 		if ( is_wp_error( $response ) ) {
+			$this->logger->error( __( 'Failed to approve join request. WordPress error: ', 'wctlgm-subscriber-manager-lite' ) . $response->get_error_message() );
 			return $response;
 		}
 
@@ -204,6 +208,7 @@ class Subscriber_Manager_Lite_WCTLGM_API_Handler {
 
 		if ( ! isset( $data['ok'] ) || ! $data['ok'] ) {
 			$error_message = isset( $data['description'] ) ? $data['description'] : 'Unknown error';
+			$this->logger->error( __( 'Failed to approve join request. Telegram API error: ', 'wctlgm-subscriber-manager-lite' ) . $body );
 			return new \WP_Error( 'telegram_api_error', $error_message );
 		}
 
@@ -228,6 +233,7 @@ class Subscriber_Manager_Lite_WCTLGM_API_Handler {
 		);
 
 		if ( is_wp_error( $response ) ) {
+			$this->logger->error( __( 'Failed to revoke invite link. WordPress error: ', 'wctlgm-subscriber-manager-lite' ) . $response->get_error_message() );
 			return $response;
 		}
 
@@ -236,6 +242,7 @@ class Subscriber_Manager_Lite_WCTLGM_API_Handler {
 
 		if ( ! isset( $data['ok'] ) || ! $data['ok'] ) {
 			$error_message = isset( $data['description'] ) ? $data['description'] : 'Unknown error';
+			$this->logger->error( __( 'Failed to revoke invite link. Telegram API error: ', 'wctlgm-subscriber-manager-lite' ) . $body );
 			return new \WP_Error( 'telegram_api_error', $error_message );
 		}
 
@@ -260,6 +267,7 @@ class Subscriber_Manager_Lite_WCTLGM_API_Handler {
 		);
 
 		if ( is_wp_error( $response ) ) {
+			$this->logger->error( __( 'Failed to deny join request. WordPress error: ', 'wctlgm-subscriber-manager-lite' ) . $response->get_error_message() );
 			return $response;
 		}
 
@@ -268,6 +276,7 @@ class Subscriber_Manager_Lite_WCTLGM_API_Handler {
 
 		if ( ! isset( $data['ok'] ) || ! $data['ok'] ) {
 			$error_message = isset( $data['description'] ) ? $data['description'] : 'Unknown error';
+			$this->logger->error( __( 'Failed to deny join request. Telegram API error: ', 'wctlgm-subscriber-manager-lite' ) . $body );
 			return new \WP_Error( 'telegram_api_error', $error_message );
 		}
 

--- a/includes/class-subscriber-manager-lite-wctlgm-api-handler.php
+++ b/includes/class-subscriber-manager-lite-wctlgm-api-handler.php
@@ -55,6 +55,8 @@ class Subscriber_Manager_Lite_WCTLGM_API_Handler {
 			return new \WP_Error( 'no_bot_token', __( 'No Bot Token found.', 'wctlgm-subscriber-manager-lite' ) );
 		}
 
+		$allowed_updates = $this->get_allowed_updates();
+
 		$api_url  = "https://api.telegram.org/bot{$this->bot_token}/setWebhook";
 		$response = wp_remote_post(
 			$api_url,
@@ -63,7 +65,7 @@ class Subscriber_Manager_Lite_WCTLGM_API_Handler {
 					array(
 						'url'             => $url,
 						'secret_token'    => $secret_token,
-						'allowed_updates' => array( 'message', 'edited_message', 'edited_channel_post', 'chat_member', 'chat_join_request' ),
+						'allowed_updates' => $allowed_updates,
 					)
 				),
 				'headers' => array(
@@ -270,5 +272,27 @@ class Subscriber_Manager_Lite_WCTLGM_API_Handler {
 		}
 
 		return $data;
+	}
+
+	/**
+	 * Get allowed updates based on activation flow setting.
+	 *
+	 * @return array
+	 */
+	private function get_allowed_updates() {
+		$require_activation = get_option( 'wctlgm_require_activation_flow', false );
+
+		// Base updates (for now)
+		$allowed_updates = array( 'chat_join_request', 'edited_message', 'edited_channel_post', 'chat_member' );
+
+		// Add message updates only if activation flow is enabled
+		if ( $require_activation ) {
+			$allowed_updates[] = 'message';
+		}
+
+		// Log allowed_updates.
+		$this->logger->info( __( 'Allowed updates: ', 'wctlgm-subscriber-manager-lite' ) . implode( ',', $allowed_updates ) );
+
+		return $allowed_updates;
 	}
 }

--- a/includes/class-subscriber-manager-lite-wctlgm-bot-interaction-handler.php
+++ b/includes/class-subscriber-manager-lite-wctlgm-bot-interaction-handler.php
@@ -12,11 +12,13 @@ namespace Subscriber_Manager_Lite_for_Telegram;
 class Subscriber_Manager_Lite_WCTLGM_Bot_Interaction_Handler {
 
 	private $api_handler;
+	private $logger;
 	private $chat_id;
 	private $user_id;
 
 	public function __construct() {
 		$this->api_handler = new \Subscriber_Manager_Lite_for_Telegram\Subscriber_Manager_Lite_WCTLGM_API_Handler();
+		$this->logger      = new \Subscriber_Manager_Lite_for_Telegram\Subscriber_Manager_Lite_WCTLGM_Logger();
 	}
 
 	public static function init() {
@@ -24,6 +26,8 @@ class Subscriber_Manager_Lite_WCTLGM_Bot_Interaction_Handler {
 	}
 
 	public function process_telegram_request( $data ) {
+		$this->logger->info( __( 'Processing Telegram request: ', 'wctlgm-subscriber-manager-lite' ) . wp_json_encode( $data ) );
+
 		if ( isset( $data['chat_join_request'] ) ) {
 			return $this->process_join_request( $data );
 		}
@@ -92,12 +96,16 @@ class Subscriber_Manager_Lite_WCTLGM_Bot_Interaction_Handler {
 		if ( $subscriptions_handler->is_join_request_valid( $user_id, $invite_link ) ) {
 			$response_approval = $this->api_handler->approve_join_request( $chat_id, $user_id );
 			$response_revoke   = $this->api_handler->revoke_invite_link( $chat_id, $invite_link );
+			$this->logger->info( __( 'Join request approved and invite link revoked: ', 'wctlgm-subscriber-manager-lite' ) . wp_json_encode( $response_approval ) . wp_json_encode( $response_revoke ) . ' - ' . $user_id . ' - ' . $chat_id );
 		} elseif ( $allow_external_invites ) {
 			// External invite link approval in case it requires approval.
+			// To-do: What if the invite link is not valid, ie from a cancelled order?
 			$response_approval = $this->api_handler->approve_join_request( $chat_id, $user_id );
+			$this->logger->info( __( 'External join request approved: ', 'wctlgm-subscriber-manager-lite' ) . wp_json_encode( $response_approval ) . ' - ' . $user_id . ' - ' . $chat_id );
 			// To-do: capture the Telegram User ID for the external invite link.
 		} else {
 			$response_deny = $this->api_handler->deny_join_request( $chat_id, $user_id );
+			$this->logger->info( __( 'Join request denied: ', 'wctlgm-subscriber-manager-lite' ) . wp_json_encode( $response_deny ) . ' - ' . $user_id . ' - ' . $chat_id );
 		}
 
 		return array( 'action' => 'none' );

--- a/includes/class-subscriber-manager-lite-wctlgm-bot-interaction-handler.php
+++ b/includes/class-subscriber-manager-lite-wctlgm-bot-interaction-handler.php
@@ -93,7 +93,7 @@ class Subscriber_Manager_Lite_WCTLGM_Bot_Interaction_Handler {
 		$subscriptions_handler  = new \Subscriber_Manager_Lite_for_Telegram\Subscriber_Manager_Lite_WCTLGM_Subscriptions_Handler();
 		$allow_external_invites = get_option( 'wctlgm_allow_external_invites', false );
 
-		if ( $subscriptions_handler->is_join_request_valid( $user_id, $invite_link, $allow_external_invites ) ) {
+		if ( $subscriptions_handler->is_join_request_valid( $user_id, $invite_link, $chat_id, $allow_external_invites ) ) {
 			$response_approval = $this->api_handler->approve_join_request( $chat_id, $user_id );
 			$response_revoke   = $this->api_handler->revoke_invite_link( $chat_id, $invite_link );
 			$this->logger->info( __( 'Join request approved and invite link revoked: ', 'wctlgm-subscriber-manager-lite' ) . wp_json_encode( $response_approval ) . wp_json_encode( $response_revoke ) . ' - ' . $user_id . ' - ' . $chat_id );

--- a/includes/class-subscriber-manager-lite-wctlgm-bot-interaction-handler.php
+++ b/includes/class-subscriber-manager-lite-wctlgm-bot-interaction-handler.php
@@ -196,10 +196,10 @@ class Subscriber_Manager_Lite_WCTLGM_Bot_Interaction_Handler {
 		if ( $result['success'] ) {
 			$message = __( 'Activation successful!', 'wctlgm-subscriber-manager-lite' );
 			if ( ! empty( $result['channels'] ) ) {
-				$message .= "\n" . __( 'Use the following link to access the private channel:', 'wctlgm-subscriber-manager-lite' );
+				$message .= "\n" . __( 'Use the following link to access the private channel or group:', 'wctlgm-subscriber-manager-lite' );
 				foreach ( $result['channels'] as $channel ) {
 					// translators: %1$s is the channel name, %2$s is the invite link
-					$message .= "\n" . sprintf( __( 'Channel: %1$s - %2$s', 'wctlgm-subscriber-manager-lite' ), $channel['name'], $channel['invite_link'] );
+					$message .= "\n" . sprintf( __( 'Channel/Group: %1$s - %2$s', 'wctlgm-subscriber-manager-lite' ), $channel['name'], $channel['invite_link'] );
 				}
 			}
 			as_schedule_single_action(

--- a/includes/class-subscriber-manager-lite-wctlgm-bot-interaction-handler.php
+++ b/includes/class-subscriber-manager-lite-wctlgm-bot-interaction-handler.php
@@ -92,7 +92,11 @@ class Subscriber_Manager_Lite_WCTLGM_Bot_Interaction_Handler {
 		if ( $subscriptions_handler->is_join_request_valid( $user_id, $invite_link ) ) {
 			$response_approval = $this->api_handler->approve_join_request( $chat_id, $user_id );
 			$response_revoke   = $this->api_handler->revoke_invite_link( $chat_id, $invite_link );
-		} elseif ( ! $allow_external_invites ) {
+		} elseif ( $allow_external_invites ) {
+			// External invite link approval in case it requires approval.
+			$response_approval = $this->api_handler->approve_join_request( $chat_id, $user_id );
+			// To-do: capture the Telegram User ID for the external invite link.
+		} else {
 			$response_deny = $this->api_handler->deny_join_request( $chat_id, $user_id );
 		}
 

--- a/includes/class-subscriber-manager-lite-wctlgm-bot-interaction-handler.php
+++ b/includes/class-subscriber-manager-lite-wctlgm-bot-interaction-handler.php
@@ -93,16 +93,10 @@ class Subscriber_Manager_Lite_WCTLGM_Bot_Interaction_Handler {
 		$subscriptions_handler  = new \Subscriber_Manager_Lite_for_Telegram\Subscriber_Manager_Lite_WCTLGM_Subscriptions_Handler();
 		$allow_external_invites = get_option( 'wctlgm_allow_external_invites', false );
 
-		if ( $subscriptions_handler->is_join_request_valid( $user_id, $invite_link ) ) {
+		if ( $subscriptions_handler->is_join_request_valid( $user_id, $invite_link, $allow_external_invites ) ) {
 			$response_approval = $this->api_handler->approve_join_request( $chat_id, $user_id );
 			$response_revoke   = $this->api_handler->revoke_invite_link( $chat_id, $invite_link );
 			$this->logger->info( __( 'Join request approved and invite link revoked: ', 'wctlgm-subscriber-manager-lite' ) . wp_json_encode( $response_approval ) . wp_json_encode( $response_revoke ) . ' - ' . $user_id . ' - ' . $chat_id );
-		} elseif ( $allow_external_invites ) {
-			// External invite link approval in case it requires approval.
-			// To-do: What if the invite link is not valid, ie from a cancelled order?
-			$response_approval = $this->api_handler->approve_join_request( $chat_id, $user_id );
-			$this->logger->info( __( 'External join request approved: ', 'wctlgm-subscriber-manager-lite' ) . wp_json_encode( $response_approval ) . ' - ' . $user_id . ' - ' . $chat_id );
-			// To-do: capture the Telegram User ID for the external invite link.
 		} else {
 			$response_deny = $this->api_handler->deny_join_request( $chat_id, $user_id );
 			$this->logger->info( __( 'Join request denied: ', 'wctlgm-subscriber-manager-lite' ) . wp_json_encode( $response_deny ) . ' - ' . $user_id . ' - ' . $chat_id );

--- a/includes/class-subscriber-manager-lite-wctlgm-email-handler.php
+++ b/includes/class-subscriber-manager-lite-wctlgm-email-handler.php
@@ -28,11 +28,13 @@ class Subscriber_Manager_Lite_WCTLGM_Email_Handler {
 	 * @return array
 	 */
 	public static function add_email_classes( $email_classes ) {
-		// Load the email class file only when WooCommerce is ready
+		// Load the email class files only when WooCommerce is ready
 		require_once WCTLGM_SML_PLUGIN_DIR . 'includes/emails/class-subscriber-manager-lite-wctlgm-activation-email.php';
+		require_once WCTLGM_SML_PLUGIN_DIR . 'includes/emails/class-subscriber-manager-lite-wctlgm-invite-links-email.php';
 
-		// Add our email class
-		$email_classes['wctlgm_activation'] = new \Subscriber_Manager_Lite_for_Telegram\Subscriber_Manager_Lite_WCTLGM_Activation_Email();
+		// Add our email classes
+		$email_classes['wctlgm_activation']   = new \Subscriber_Manager_Lite_for_Telegram\Subscriber_Manager_Lite_WCTLGM_Activation_Email();
+		$email_classes['wctlgm_invite_links'] = new \Subscriber_Manager_Lite_for_Telegram\Subscriber_Manager_Lite_WCTLGM_Invite_Links_Email();
 
 		return $email_classes;
 	}

--- a/includes/class-subscriber-manager-lite-wctlgm-order-handler.php
+++ b/includes/class-subscriber-manager-lite-wctlgm-order-handler.php
@@ -14,21 +14,29 @@ use Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils;
 class Subscriber_Manager_Lite_WCTLGM_Order_Handler {
 
 	public static function init() {
-		add_action( 'woocommerce_checkout_update_order_meta', array( __CLASS__, 'maybe_process_order' ), 11, 1 );
-		add_action( 'woocommerce_store_api_checkout_update_order_meta', array( __CLASS__, 'maybe_process_order' ), 11, 1 );
+		add_action( 'woocommerce_order_status_changed', array( __CLASS__, 'maybe_process_order' ), 10, 3 );
 		add_action( 'woocommerce_email_order_details', array( __CLASS__, 'wctlgm_email_activation_info' ), 10, 4 );
 		add_action( 'woocommerce_order_details_before_order_table', array( __CLASS__, 'display_activation_code_in_order_details' ), 10, 1 );
+		add_action( 'wctlgm_send_invite_links_email', array( __CLASS__, 'send_invite_links_email' ), 10, 1 );
 	}
 
-	public static function maybe_process_order( $order ) {
-		if ( is_numeric( $order ) ) {
-			$order_id = $order;
-			$order    = wc_get_order( $order_id );
-		} else {
-			$order_id = $order->get_id();
+	public static function maybe_process_order( $order_id, $old_status, $new_status ) {
+		$order = wc_get_order( $order_id );
+
+		if ( ! $order ) {
+			return;
 		}
 
 		if ( ! self::order_has_telegram_product( $order ) ) {
+			return;
+		}
+
+		if ( ! in_array( $new_status, array( 'processing', 'completed' ), true ) ) {
+			return;
+		}
+
+		// Skip if already processed (processing → completed)
+		if ( 'processing' === $old_status && 'completed' === $new_status ) {
 			return;
 		}
 
@@ -40,7 +48,7 @@ class Subscriber_Manager_Lite_WCTLGM_Order_Handler {
 			}
 			$code_generated = self::generate_activation_code( $order );
 		} else {
-			// Generate invites directly when activation flow is disabled
+			// Generate invites immediately when activation flow is disabled
 			self::generate_and_store_invites( $order );
 		}
 	}
@@ -82,16 +90,16 @@ class Subscriber_Manager_Lite_WCTLGM_Order_Handler {
 	}
 
 	/**
-	 * Email activation info or invite links to the customer when the order is completed.
-	 * Injects into WooCommerce's order completed email.
+	 * Email activation info to the customer when the order is completed.
+	 * Injects into WooCommerce's order processing or completed email.
 	 */
 	public static function wctlgm_email_activation_info( $order, $sent_to_admin, $plain_text, $email ) {
 		if ( 'customer_completed_order' === $email->id || 'customer_processing_order' === $email->id ) {
-			self::email_activation_info( $order, $plain_text );
+			self::maybe_email_activation_info( $order, $plain_text );
 		}
 	}
 
-	private static function email_activation_info( $order, $plain_text = false ) {
+	private static function maybe_email_activation_info( $order, $plain_text = false ) {
 		$require_activation = get_option( 'wctlgm_require_activation_flow', true );
 
 		if ( $require_activation ) {
@@ -112,9 +120,6 @@ class Subscriber_Manager_Lite_WCTLGM_Order_Handler {
 					);
 				}
 			}
-		} else {
-			// Show invite links when activation is disabled
-			self::email_invite_links( $order, $plain_text );
 		}
 	}
 
@@ -149,7 +154,7 @@ class Subscriber_Manager_Lite_WCTLGM_Order_Handler {
 				echo wp_kses_post( self::get_activation_info_text_for_order( $order, $activation_code ) );
 			}
 		} else {
-			// Display invite links when activation is disabled
+			// Display invite links when activation flow is disabled
 			self::display_invite_links_in_order_details( $order );
 		}
 	}
@@ -178,78 +183,42 @@ class Subscriber_Manager_Lite_WCTLGM_Order_Handler {
 		$response              = $subscriptions_handler->get_channel_invites( $order );
 		if ( $response['success'] && ! empty( $response['channels'] ) ) {
 			foreach ( $response['channels'] as $invite ) {
+				// To-do: Index the invite link meta key with the channel ID. Maybe.
 				$order->add_meta_data( '_channel_invite', sanitize_url( $invite['invite_link'] ) );
 			}
 			$order->save();
+
+			// Schedule email to be sent with a slight delay using Action Scheduler
+			as_schedule_single_action(
+				time() + 5, // 5 seconds delay
+				'wctlgm_send_invite_links_email',
+				array( array( $order->get_id(), $response['channels'] ) ),
+			);
 		}
 	}
 
 	/**
-	 * Email invite links when activation is disabled.
+	 * Send invite links email via Action Scheduler.
+	 *
+	 * @param array $data Array containing order_id and invites data.
 	 */
-	private static function email_invite_links( $order, $plain_text = false ) {
-		$invites = $order->get_meta( '_channel_invite', false );
-		if ( empty( $invites ) ) {
-			// Generate invites if not already stored
-			self::generate_and_store_invites( $order );
-			$invites = $order->get_meta( '_channel_invite', false );
-		}
-
-		if ( empty( $invites ) ) {
+	public static function send_invite_links_email( $data ) {
+		if ( empty( $data ) || ! is_array( $data ) || count( $data ) < 2 ) {
 			return;
 		}
 
-		// Get channel names for display
-		$channels      = get_option( 'wctlgm_channels', array() );
-		$channel_names = array();
-		foreach ( $channels as $channel ) {
-			$channel_names[ $channel['id'] ] = $channel['name'];
+		$order_id = $data[0];
+		$invites  = $data[1];
+
+		$order = wc_get_order( $order_id );
+		if ( ! $order ) {
+			return;
 		}
 
-		if ( $plain_text ) {
-			echo "\n" . esc_html__( 'Telegram Channel Access:', 'wctlgm-subscriber-manager-lite' );
-			foreach ( $invites as $invite_link ) {
-				// Find channel name by matching invite link to stored channel IDs
-				$channel_name = 'Channel';
-				foreach ( $order->get_items() as $item ) {
-					$product_id  = $item->get_product_id();
-					$channel_ids = get_post_meta( $product_id, '_telegram_channel_ids', true );
-					if ( ! empty( $channel_ids ) ) {
-						foreach ( $channel_ids as $channel_id ) {
-							if ( isset( $channel_names[ $channel_id ] ) ) {
-								$channel_name = $channel_names[ $channel_id ];
-								break 2;
-							}
-						}
-					}
-				}
-				echo "\n" . esc_html( $channel_name ) . ': ' . esc_url( $invite_link );
-			}
-		} else {
-			echo '<h2>' . esc_html__( 'Telegram Channel Access', 'wctlgm-subscriber-manager-lite' ) . '</h2>';
-			echo '<p>' . esc_html__( 'Below are your private channel invite links:', 'wctlgm-subscriber-manager-lite' ) . '</p>';
-			foreach ( $invites as $invite_link ) {
-				// Find channel name by matching invite link to stored channel IDs
-				$channel_name = 'Channel';
-				foreach ( $order->get_items() as $item ) {
-					$product_id  = $item->get_product_id();
-					$channel_ids = get_post_meta( $product_id, '_telegram_channel_ids', true );
-					if ( ! empty( $channel_ids ) ) {
-						foreach ( $channel_ids as $channel_id ) {
-							if ( isset( $channel_names[ $channel_id ] ) ) {
-								$channel_name = $channel_names[ $channel_id ];
-								break 2;
-							}
-						}
-					}
-				}
-				printf(
-					'<p><strong>%s:</strong> <a href="%s" target="_blank">%s</a></p>',
-					esc_html( $channel_name ),
-					esc_url( $invite_link ),
-					esc_html__( 'Join Channel', 'wctlgm-subscriber-manager-lite' )
-				);
-			}
+		// Get the email instance
+		$email = \WC_Emails::instance()->emails['wctlgm_invite_links'];
+		if ( $email ) {
+			$email->trigger( $order_id, $invites );
 		}
 	}
 
@@ -261,7 +230,8 @@ class Subscriber_Manager_Lite_WCTLGM_Order_Handler {
 		if ( empty( $invites ) ) {
 			// Generate invites if not already stored
 			self::generate_and_store_invites( $order );
-			$invites = $order->get_meta( '_channel_invite', false );}
+			$invites = $order->get_meta( '_channel_invite', false );
+		}
 
 		if ( empty( $invites ) ) {
 			echo '<h2>' . esc_html__( 'Telegram Channel Access', 'wctlgm-subscriber-manager-lite' ) . '</h2>';
@@ -278,7 +248,10 @@ class Subscriber_Manager_Lite_WCTLGM_Order_Handler {
 
 		echo '<h2>' . esc_html__( 'Telegram Channel Access', 'wctlgm-subscriber-manager-lite' ) . '</h2>';
 		echo '<p>' . esc_html__( 'Below are your private channel invite links:', 'wctlgm-subscriber-manager-lite' ) . '</p>';
-		foreach ( $invites as $invite_link ) {
+		foreach ( $invites as $invite_meta ) {
+			// Extract the actual value from WC_Meta_Data object
+			$invite_link = is_object( $invite_meta ) ? $invite_meta->get_data()['value'] : $invite_meta;
+
 			// Find channel name by matching invite link to stored channel IDs
 			$channel_name = 'Channel';
 			foreach ( $order->get_items() as $item ) {

--- a/includes/class-subscriber-manager-lite-wctlgm-order-handler.php
+++ b/includes/class-subscriber-manager-lite-wctlgm-order-handler.php
@@ -216,8 +216,9 @@ class Subscriber_Manager_Lite_WCTLGM_Order_Handler {
 		}
 
 		// Get the email instance
-		$email = \WC_Emails::instance()->emails['wctlgm_invite_links'];
-		if ( $email ) {
+		$emails = \WC_Emails::instance()->emails;
+		if ( isset( $emails['wctlgm_invite_links'] ) ) {
+			$email = $emails['wctlgm_invite_links'];
 			$email->trigger( $order_id, $invites );
 		}
 	}

--- a/includes/class-subscriber-manager-lite-wctlgm-order-handler.php
+++ b/includes/class-subscriber-manager-lite-wctlgm-order-handler.php
@@ -133,9 +133,9 @@ class Subscriber_Manager_Lite_WCTLGM_Order_Handler {
 		if ( ! in_array( $order->get_status(), array( 'processing', 'completed' ), true ) ) {
 			if ( $require_activation ) {
 				echo '<h2>' . esc_html__( 'Telegram Activation Code', 'wctlgm-subscriber-manager-lite' ) . '</h2>';
-				echo '<p>' . esc_html__( 'Telegram Channel activation details will be emailed and available in your dashboard after payment processing is complete.', 'wctlgm-subscriber-manager-lite' ) . '</p>';
+				echo '<p>' . esc_html__( 'Telegram access activation details will be emailed and available in your dashboard after payment processing is complete.', 'wctlgm-subscriber-manager-lite' ) . '</p>';
 			} else {
-				echo '<h2>' . esc_html__( 'Telegram Channel Access', 'wctlgm-subscriber-manager-lite' ) . '</h2>';
+				echo '<h2>' . esc_html__( 'Telegram Access', 'wctlgm-subscriber-manager-lite' ) . '</h2>';
 				echo '<p>' . esc_html__( 'Invite links will be emailed and available in your dashboard after payment processing is complete.', 'wctlgm-subscriber-manager-lite' ) . '</p>';
 			}
 			return;
@@ -235,25 +235,25 @@ class Subscriber_Manager_Lite_WCTLGM_Order_Handler {
 		}
 
 		if ( empty( $invites ) ) {
-			echo '<h2>' . esc_html__( 'Telegram Channel Access', 'wctlgm-subscriber-manager-lite' ) . '</h2>';
-			echo '<p>' . esc_html__( 'No channels available for this order.', 'wctlgm-subscriber-manager-lite' ) . '</p>';
+			echo '<h2>' . esc_html__( 'Telegram Access', 'wctlgm-subscriber-manager-lite' ) . '</h2>';
+			echo '<p>' . esc_html__( 'No Telegram access available for this order.', 'wctlgm-subscriber-manager-lite' ) . '</p>';
 			return;
 		}
 
-		echo '<h2>' . esc_html__( 'Telegram Channel Access', 'wctlgm-subscriber-manager-lite' ) . '</h2>';
-		echo '<p>' . esc_html__( 'Below are your private channel invite links:', 'wctlgm-subscriber-manager-lite' ) . '</p>';
+		echo '<h2>' . esc_html__( 'Telegram Access', 'wctlgm-subscriber-manager-lite' ) . '</h2>';
+		echo '<p>' . esc_html__( 'Below are your private invite links:', 'wctlgm-subscriber-manager-lite' ) . '</p>';
 		foreach ( $invites as $invite ) {
 			printf(
 				'<p><strong>%s:</strong> <a href="%s" target="_blank">%s</a></p>',
 				esc_html( $invite['name'] ),
 				esc_url( $invite['invite_link'] ),
-				esc_html__( 'Join Channel', 'wctlgm-subscriber-manager-lite' )
+				esc_html__( 'Join', 'wctlgm-subscriber-manager-lite' )
 			);
 		}
 	}
 
 	/**
-	 * Get all channel invites for an order using indexed meta keys.
+	 * Get all channel or group invites for an order using indexed meta keys.
 	 *
 	 * @param WC_Order $order The order object.
 	 * @return array Array of invite data with channel_id, channel_name, and invite_link.
@@ -265,7 +265,7 @@ class Subscriber_Manager_Lite_WCTLGM_Order_Handler {
 		foreach ( $meta_data as $meta ) {
 			$meta_key   = $meta->get_data()['key'];
 			$meta_value = $meta->get_data()['value'];
-			// Check if this is a channel invite meta
+			// Check if this is a channel or group invite meta
 			if ( strpos( $meta_key, '_channel_invite_' ) === 0 ) {
 				// Extract channel ID from meta key
 				$channel_id = str_replace( '_channel_invite_', '', $meta_key );
@@ -273,7 +273,7 @@ class Subscriber_Manager_Lite_WCTLGM_Order_Handler {
 				$channel_name = self::get_channel_name_by_id( $channel_id );
 				$invites[]    = array(
 					'channel_id'  => $channel_id,
-					'name'        => $channel_name ? $channel_name : 'Channel',
+					'name'        => $channel_name ? $channel_name : 'Channel or Group',
 					'invite_link' => $meta_value,
 				);
 			}
@@ -282,10 +282,10 @@ class Subscriber_Manager_Lite_WCTLGM_Order_Handler {
 	}
 
 	/**
-	 * Get channel name by channel ID.
+	 * Get channel or group name by ID.
 	 *
-	 * @param string $channel_id The channel ID.
-	 * @return string|null The channel name or null if not found.
+	 * @param string $channel_id The channel or group ID.
+	 * @return string|null The channel or group name or null if not found.
 	 */
 	private static function get_channel_name_by_id( $channel_id ) {
 		$channels = get_option( 'wctlgm_channels', array() );

--- a/includes/class-subscriber-manager-lite-wctlgm-order-handler.php
+++ b/includes/class-subscriber-manager-lite-wctlgm-order-handler.php
@@ -40,7 +40,7 @@ class Subscriber_Manager_Lite_WCTLGM_Order_Handler {
 			return;
 		}
 
-		$require_activation = get_option( 'wctlgm_require_activation_flow', true );
+		$require_activation = get_option( 'wctlgm_require_activation_flow', false );
 
 		if ( $require_activation ) {
 			if ( $order->get_meta( '_activation_code', true ) ) {
@@ -100,7 +100,7 @@ class Subscriber_Manager_Lite_WCTLGM_Order_Handler {
 	}
 
 	private static function maybe_email_activation_info( $order, $plain_text = false ) {
-		$require_activation = get_option( 'wctlgm_require_activation_flow', true );
+		$require_activation = get_option( 'wctlgm_require_activation_flow', false );
 
 		if ( $require_activation ) {
 			$bot_url         = get_option( 'wctlgm_bot_url' );
@@ -128,7 +128,7 @@ class Subscriber_Manager_Lite_WCTLGM_Order_Handler {
 			return;
 		}
 
-		$require_activation = get_option( 'wctlgm_require_activation_flow', true );
+		$require_activation = get_option( 'wctlgm_require_activation_flow', false );
 
 		if ( ! in_array( $order->get_status(), array( 'processing', 'completed' ), true ) ) {
 			if ( $require_activation ) {

--- a/includes/class-subscriber-manager-lite-wctlgm-order-handler.php
+++ b/includes/class-subscriber-manager-lite-wctlgm-order-handler.php
@@ -48,8 +48,11 @@ class Subscriber_Manager_Lite_WCTLGM_Order_Handler {
 			}
 			$code_generated = self::generate_activation_code( $order );
 		} else {
-			// Generate invites immediately when activation flow is disabled
-			self::generate_and_store_invites( $order );
+			// Check if invites already exist before generating
+			$existing_invites = self::get_all_channel_invites_for_order( $order );
+			if ( empty( $existing_invites ) ) {
+				self::generate_and_store_invites( $order );
+			}
 		}
 	}
 
@@ -216,7 +219,7 @@ class Subscriber_Manager_Lite_WCTLGM_Order_Handler {
 		}
 
 		// Get the email instance
-		$emails = \WC_Emails::instance()->emails;
+		$emails = WC()->mailer()->get_emails();
 		if ( isset( $emails['wctlgm_invite_links'] ) ) {
 			$email = $emails['wctlgm_invite_links'];
 			$email->trigger( $order_id, $invites );

--- a/includes/class-subscriber-manager-lite-wctlgm-order-handler.php
+++ b/includes/class-subscriber-manager-lite-wctlgm-order-handler.php
@@ -17,7 +17,6 @@ class Subscriber_Manager_Lite_WCTLGM_Order_Handler {
 		add_action( 'woocommerce_checkout_update_order_meta', array( __CLASS__, 'maybe_process_order' ), 11, 1 );
 		add_action( 'woocommerce_store_api_checkout_update_order_meta', array( __CLASS__, 'maybe_process_order' ), 11, 1 );
 		add_action( 'woocommerce_email_order_details', array( __CLASS__, 'wctlgm_email_activation_info' ), 10, 4 );
-		add_action( 'woocommerce_order_status_completed', array( __CLASS__, 'send_activation_email_on_completion' ), 10, 1 );
 		add_action( 'woocommerce_order_details_before_order_table', array( __CLASS__, 'display_activation_code_in_order_details' ), 10, 1 );
 	}
 
@@ -29,11 +28,21 @@ class Subscriber_Manager_Lite_WCTLGM_Order_Handler {
 			$order_id = $order->get_id();
 		}
 
-		if ( $order->get_meta( '_activation_code', true ) || ! self::order_has_telegram_product( $order ) ) {
+		if ( ! self::order_has_telegram_product( $order ) ) {
 			return;
 		}
 
-		$code_generated = self::generate_activation_code( $order );
+		$require_activation = get_option( 'wctlgm_require_activation_flow', true );
+
+		if ( $require_activation ) {
+			if ( $order->get_meta( '_activation_code', true ) ) {
+				return;
+			}
+			$code_generated = self::generate_activation_code( $order );
+		} else {
+			// Generate invites directly when activation flow is disabled
+			self::generate_and_store_invites( $order );
+		}
 	}
 
 	public static function generate_activation_code( $order ) {
@@ -72,6 +81,10 @@ class Subscriber_Manager_Lite_WCTLGM_Order_Handler {
 		return $output;
 	}
 
+	/**
+	 * Email activation info or invite links to the customer when the order is completed.
+	 * Injects into WooCommerce's order completed email.
+	 */
 	public static function wctlgm_email_activation_info( $order, $sent_to_admin, $plain_text, $email ) {
 		if ( 'customer_completed_order' === $email->id || 'customer_processing_order' === $email->id ) {
 			self::email_activation_info( $order, $plain_text );
@@ -79,28 +92,30 @@ class Subscriber_Manager_Lite_WCTLGM_Order_Handler {
 	}
 
 	private static function email_activation_info( $order, $plain_text = false ) {
-		$bot_url         = get_option( 'wctlgm_bot_url' );
-		$activation_code = $order->get_meta( '_activation_code', true );
-		if ( ! empty( $activation_code ) ) {
-			if ( $plain_text ) {
-				echo "\n" . esc_html__( 'Telegram Activation Code:', 'wctlgm-subscriber-manager-lite' ) . ' ' . esc_html( $activation_code );
-				echo "\n" . esc_html__( 'Please click on the following link to open Telegram and enter your activation code in our Telegram bot:', 'wctlgm-subscriber-manager-lite' ) . ' ' . esc_url( $bot_url ) . '?activate=' . esc_html( $activation_code );
-			} else {
-				echo '<h2>' . esc_html__( 'Telegram Activation Code', 'wctlgm-subscriber-manager-lite' ) . '</h2>';
-				echo '<p>' . esc_html__( 'Here is your activation code:', 'wctlgm-subscriber-manager-lite' ) . ' <strong>' . esc_html( $activation_code ) . '</strong></p>';
-				printf(
-					'<p>%s <a href="%s" target="_blank">%s</a></p>',
-					esc_html( __( 'Please click on the following link to open Telegram and enter your activation code in our Telegram bot:', 'wctlgm-subscriber-manager-lite' ) ),
-					esc_url( $bot_url . '?start=' . $activation_code ),
-					esc_html( __( 'Start Chat', 'wctlgm-subscriber-manager-lite' ) )
-				);
-			}
-		}
-	}
+		$require_activation = get_option( 'wctlgm_require_activation_flow', true );
 
-	public static function send_activation_email_on_completion( $order_id ) {
-		$order = wc_get_order( $order_id );
-		self::email_activation_info( $order, false );
+		if ( $require_activation ) {
+			$bot_url         = get_option( 'wctlgm_bot_url' );
+			$activation_code = $order->get_meta( '_activation_code', true );
+			if ( ! empty( $activation_code ) ) {
+				if ( $plain_text ) {
+					echo "\n" . esc_html__( 'Telegram Activation Code:', 'wctlgm-subscriber-manager-lite' ) . ' ' . esc_html( $activation_code );
+					echo "\n" . esc_html__( 'Please click on the following link to open Telegram and enter your activation code in our Telegram bot:', 'wctlgm-subscriber-manager-lite' ) . ' ' . esc_url( $bot_url ) . '?activate=' . esc_html( $activation_code );
+				} else {
+					echo '<h2>' . esc_html__( 'Telegram Activation Code', 'wctlgm-subscriber-manager-lite' ) . '</h2>';
+					echo '<p>' . esc_html__( 'Here is your activation code:', 'wctlgm-subscriber-manager-lite' ) . ' <strong>' . esc_html( $activation_code ) . '</strong></p>';
+					printf(
+						'<p>%s <a href="%s" target="_blank">%s</a></p>',
+						esc_html( __( 'Please click on the following link to open Telegram and enter your activation code in our Telegram bot:', 'wctlgm-subscriber-manager-lite' ) ),
+						esc_url( $bot_url . '?start=' . $activation_code ),
+						esc_html( __( 'Start Chat', 'wctlgm-subscriber-manager-lite' ) )
+					);
+				}
+			}
+		} else {
+			// Show invite links when activation is disabled
+			self::email_invite_links( $order, $plain_text );
+		}
 	}
 
 	public static function display_activation_code_in_order_details( $order ) {
@@ -108,22 +123,34 @@ class Subscriber_Manager_Lite_WCTLGM_Order_Handler {
 			return;
 		}
 
+		$require_activation = get_option( 'wctlgm_require_activation_flow', true );
+
 		if ( ! in_array( $order->get_status(), array( 'processing', 'completed' ), true ) ) {
-			echo '<h2>' . esc_html__( 'Telegram Activation Code', 'wctlgm-subscriber-manager-lite' ) . '</h2>';
-			echo '<p>' . esc_html__( 'Telegram Channel activation details will be emailed and available in your dashboard when payment is received.', 'wctlgm-subscriber-manager-lite' ) . '</p>';
+			if ( $require_activation ) {
+				echo '<h2>' . esc_html__( 'Telegram Activation Code', 'wctlgm-subscriber-manager-lite' ) . '</h2>';
+				echo '<p>' . esc_html__( 'Telegram Channel activation details will be emailed and available in your dashboard after payment processing is complete.', 'wctlgm-subscriber-manager-lite' ) . '</p>';
+			} else {
+				echo '<h2>' . esc_html__( 'Telegram Channel Access', 'wctlgm-subscriber-manager-lite' ) . '</h2>';
+				echo '<p>' . esc_html__( 'Invite links will be emailed and available in your dashboard after payment processing is complete.', 'wctlgm-subscriber-manager-lite' ) . '</p>';
+			}
 			return;
 		}
 
-		$activation_code  = $order->get_meta( '_activation_code', true );
-		$telegram_user_id = $order->get_meta( '_telegram_user_id', true );
+		if ( $require_activation ) {
+			$activation_code  = $order->get_meta( '_activation_code', true );
+			$telegram_user_id = $order->get_meta( '_telegram_user_id', true );
 
-		$is_activated = ! empty( $telegram_user_id ) || empty( $activation_code );
+			$is_activated = ! empty( $telegram_user_id ) || empty( $activation_code );
 
-		if ( $is_activated ) {
-			echo '<h2>' . esc_html__( 'Telegram Activation Code', 'wctlgm-subscriber-manager-lite' ) . '</h2>';
-			echo '<p>' . esc_html__( 'Activated', 'wctlgm-subscriber-manager-lite' ) . '</p>';
+			if ( $is_activated ) {
+				echo '<h2>' . esc_html__( 'Telegram Activation Code', 'wctlgm-subscriber-manager-lite' ) . '</h2>';
+				echo '<p>' . esc_html__( 'Activated', 'wctlgm-subscriber-manager-lite' ) . '</p>';
+			} else {
+				echo wp_kses_post( self::get_activation_info_text_for_order( $order, $activation_code ) );
+			}
 		} else {
-			echo wp_kses_post( self::get_activation_info_text_for_order( $order, $activation_code ) );
+			// Display invite links when activation is disabled
+			self::display_invite_links_in_order_details( $order );
 		}
 	}
 
@@ -141,5 +168,137 @@ class Subscriber_Manager_Lite_WCTLGM_Order_Handler {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Generate and store invite links for an order when activation is disabled.
+	 */
+	private static function generate_and_store_invites( $order ) {
+		$subscriptions_handler = new \Subscriber_Manager_Lite_for_Telegram\Subscriber_Manager_Lite_WCTLGM_Subscriptions_Handler();
+		$response              = $subscriptions_handler->get_channel_invites( $order );
+		if ( $response['success'] && ! empty( $response['channels'] ) ) {
+			foreach ( $response['channels'] as $invite ) {
+				$order->add_meta_data( '_channel_invite', sanitize_url( $invite['invite_link'] ) );
+			}
+			$order->save();
+		}
+	}
+
+	/**
+	 * Email invite links when activation is disabled.
+	 */
+	private static function email_invite_links( $order, $plain_text = false ) {
+		$invites = $order->get_meta( '_channel_invite', false );
+		if ( empty( $invites ) ) {
+			// Generate invites if not already stored
+			self::generate_and_store_invites( $order );
+			$invites = $order->get_meta( '_channel_invite', false );
+		}
+
+		if ( empty( $invites ) ) {
+			return;
+		}
+
+		// Get channel names for display
+		$channels      = get_option( 'wctlgm_channels', array() );
+		$channel_names = array();
+		foreach ( $channels as $channel ) {
+			$channel_names[ $channel['id'] ] = $channel['name'];
+		}
+
+		if ( $plain_text ) {
+			echo "\n" . esc_html__( 'Telegram Channel Access:', 'wctlgm-subscriber-manager-lite' );
+			foreach ( $invites as $invite_link ) {
+				// Find channel name by matching invite link to stored channel IDs
+				$channel_name = 'Channel';
+				foreach ( $order->get_items() as $item ) {
+					$product_id  = $item->get_product_id();
+					$channel_ids = get_post_meta( $product_id, '_telegram_channel_ids', true );
+					if ( ! empty( $channel_ids ) ) {
+						foreach ( $channel_ids as $channel_id ) {
+							if ( isset( $channel_names[ $channel_id ] ) ) {
+								$channel_name = $channel_names[ $channel_id ];
+								break 2;
+							}
+						}
+					}
+				}
+				echo "\n" . esc_html( $channel_name ) . ': ' . esc_url( $invite_link );
+			}
+		} else {
+			echo '<h2>' . esc_html__( 'Telegram Channel Access', 'wctlgm-subscriber-manager-lite' ) . '</h2>';
+			echo '<p>' . esc_html__( 'Below are your private channel invite links:', 'wctlgm-subscriber-manager-lite' ) . '</p>';
+			foreach ( $invites as $invite_link ) {
+				// Find channel name by matching invite link to stored channel IDs
+				$channel_name = 'Channel';
+				foreach ( $order->get_items() as $item ) {
+					$product_id  = $item->get_product_id();
+					$channel_ids = get_post_meta( $product_id, '_telegram_channel_ids', true );
+					if ( ! empty( $channel_ids ) ) {
+						foreach ( $channel_ids as $channel_id ) {
+							if ( isset( $channel_names[ $channel_id ] ) ) {
+								$channel_name = $channel_names[ $channel_id ];
+								break 2;
+							}
+						}
+					}
+				}
+				printf(
+					'<p><strong>%s:</strong> <a href="%s" target="_blank">%s</a></p>',
+					esc_html( $channel_name ),
+					esc_url( $invite_link ),
+					esc_html__( 'Join Channel', 'wctlgm-subscriber-manager-lite' )
+				);
+			}
+		}
+	}
+
+	/**
+	 * Display invite links in order details when activation is disabled.
+	 */
+	private static function display_invite_links_in_order_details( $order ) {
+		$invites = $order->get_meta( '_channel_invite', false );
+		if ( empty( $invites ) ) {
+			// Generate invites if not already stored
+			self::generate_and_store_invites( $order );
+			$invites = $order->get_meta( '_channel_invite', false );}
+
+		if ( empty( $invites ) ) {
+			echo '<h2>' . esc_html__( 'Telegram Channel Access', 'wctlgm-subscriber-manager-lite' ) . '</h2>';
+			echo '<p>' . esc_html__( 'No channels available for this order.', 'wctlgm-subscriber-manager-lite' ) . '</p>';
+			return;
+		}
+
+		// Get channel names for display
+		$channels      = get_option( 'wctlgm_channels', array() );
+		$channel_names = array();
+		foreach ( $channels as $channel ) {
+			$channel_names[ $channel['id'] ] = $channel['name'];
+		}
+
+		echo '<h2>' . esc_html__( 'Telegram Channel Access', 'wctlgm-subscriber-manager-lite' ) . '</h2>';
+		echo '<p>' . esc_html__( 'Below are your private channel invite links:', 'wctlgm-subscriber-manager-lite' ) . '</p>';
+		foreach ( $invites as $invite_link ) {
+			// Find channel name by matching invite link to stored channel IDs
+			$channel_name = 'Channel';
+			foreach ( $order->get_items() as $item ) {
+				$product_id  = $item->get_product_id();
+				$channel_ids = get_post_meta( $product_id, '_telegram_channel_ids', true );
+				if ( ! empty( $channel_ids ) ) {
+					foreach ( $channel_ids as $channel_id ) {
+						if ( isset( $channel_names[ $channel_id ] ) ) {
+							$channel_name = $channel_names[ $channel_id ];
+							break 2;
+						}
+					}
+				}
+			}
+			printf(
+				'<p><strong>%s:</strong> <a href="%s" target="_blank">%s</a></p>',
+				esc_html( $channel_name ),
+				esc_url( $invite_link ),
+				esc_html__( 'Join Channel', 'wctlgm-subscriber-manager-lite' )
+			);
+		}
 	}
 }

--- a/includes/class-subscriber-manager-lite-wctlgm-order-handler.php
+++ b/includes/class-subscriber-manager-lite-wctlgm-order-handler.php
@@ -78,7 +78,7 @@ class Subscriber_Manager_Lite_WCTLGM_Order_Handler {
 
 	private static function get_activation_info_text_for_order( $order, $activation_code ) {
 		$bot_url = get_option( 'wctlgm_bot_url' );
-		$output .= '<h2>' . esc_html__( 'Telegram Activation Code', 'wctlgm-subscriber-manager-lite' ) . '</h2>';
+		$output  = '<h2>' . esc_html__( 'Telegram Activation Code', 'wctlgm-subscriber-manager-lite' ) . '</h2>';
 		$output .= '<p>' . esc_html__( 'Here is your activation code:', 'wctlgm-subscriber-manager-lite' ) . ' <strong>' . esc_html( $activation_code ) . '</strong></p>';
 		$output .= sprintf(
 			'<p>%s <a href="%s" target="_blank">%s</a></p>',
@@ -183,8 +183,8 @@ class Subscriber_Manager_Lite_WCTLGM_Order_Handler {
 		$response              = $subscriptions_handler->get_channel_invites( $order );
 		if ( $response['success'] && ! empty( $response['channels'] ) ) {
 			foreach ( $response['channels'] as $invite ) {
-				// To-do: Index the invite link meta key with the channel ID. Maybe.
-				$order->add_meta_data( '_channel_invite', sanitize_url( $invite['invite_link'] ) );
+				// Store invite link with channel ID as meta key suffix
+				$order->add_meta_data( '_channel_invite_' . $invite['channel_id'], sanitize_url( $invite['invite_link'] ) );
 			}
 			$order->save();
 
@@ -226,11 +226,12 @@ class Subscriber_Manager_Lite_WCTLGM_Order_Handler {
 	 * Display invite links in order details when activation is disabled.
 	 */
 	private static function display_invite_links_in_order_details( $order ) {
-		$invites = $order->get_meta( '_channel_invite', false );
+		// Get all indexed channel invite meta data
+		$invites = self::get_all_channel_invites_for_order( $order );
 		if ( empty( $invites ) ) {
 			// Generate invites if not already stored
 			self::generate_and_store_invites( $order );
-			$invites = $order->get_meta( '_channel_invite', false );
+			$invites = self::get_all_channel_invites_for_order( $order );
 		}
 
 		if ( empty( $invites ) ) {
@@ -239,39 +240,62 @@ class Subscriber_Manager_Lite_WCTLGM_Order_Handler {
 			return;
 		}
 
-		// Get channel names for display
-		$channels      = get_option( 'wctlgm_channels', array() );
-		$channel_names = array();
-		foreach ( $channels as $channel ) {
-			$channel_names[ $channel['id'] ] = $channel['name'];
-		}
-
 		echo '<h2>' . esc_html__( 'Telegram Channel Access', 'wctlgm-subscriber-manager-lite' ) . '</h2>';
 		echo '<p>' . esc_html__( 'Below are your private channel invite links:', 'wctlgm-subscriber-manager-lite' ) . '</p>';
-		foreach ( $invites as $invite_meta ) {
-			// Extract the actual value from WC_Meta_Data object
-			$invite_link = is_object( $invite_meta ) ? $invite_meta->get_data()['value'] : $invite_meta;
-
-			// Find channel name by matching invite link to stored channel IDs
-			$channel_name = 'Channel';
-			foreach ( $order->get_items() as $item ) {
-				$product_id  = $item->get_product_id();
-				$channel_ids = get_post_meta( $product_id, '_telegram_channel_ids', true );
-				if ( ! empty( $channel_ids ) ) {
-					foreach ( $channel_ids as $channel_id ) {
-						if ( isset( $channel_names[ $channel_id ] ) ) {
-							$channel_name = $channel_names[ $channel_id ];
-							break 2;
-						}
-					}
-				}
-			}
+		foreach ( $invites as $invite ) {
 			printf(
 				'<p><strong>%s:</strong> <a href="%s" target="_blank">%s</a></p>',
-				esc_html( $channel_name ),
-				esc_url( $invite_link ),
+				esc_html( $invite['name'] ),
+				esc_url( $invite['invite_link'] ),
 				esc_html__( 'Join Channel', 'wctlgm-subscriber-manager-lite' )
 			);
 		}
+	}
+
+	/**
+	 * Get all channel invites for an order using indexed meta keys.
+	 *
+	 * @param WC_Order $order The order object.
+	 * @return array Array of invite data with channel_id, channel_name, and invite_link.
+	 */
+	private static function get_all_channel_invites_for_order( $order ) {
+		$invites = array();
+		// Get all meta data for this order
+		$meta_data = $order->get_meta_data();
+		foreach ( $meta_data as $meta ) {
+			$meta_key   = $meta->get_data()['key'];
+			$meta_value = $meta->get_data()['value'];
+			// Check if this is a channel invite meta
+			if ( strpos( $meta_key, '_channel_invite_' ) === 0 ) {
+				// Extract channel ID from meta key
+				$channel_id = str_replace( '_channel_invite_', '', $meta_key );
+				// Get channel name
+				$channel_name = self::get_channel_name_by_id( $channel_id );
+				$invites[]    = array(
+					'channel_id'  => $channel_id,
+					'name'        => $channel_name ? $channel_name : 'Channel',
+					'invite_link' => $meta_value,
+				);
+			}
+		}
+		return $invites;
+	}
+
+	/**
+	 * Get channel name by channel ID.
+	 *
+	 * @param string $channel_id The channel ID.
+	 * @return string|null The channel name or null if not found.
+	 */
+	private static function get_channel_name_by_id( $channel_id ) {
+		$channels = get_option( 'wctlgm_channels', array() );
+
+		foreach ( $channels as $channel ) {
+			if ( $channel['id'] === $channel_id ) {
+				return $channel['name'];
+			}
+		}
+
+		return null;
 	}
 }

--- a/includes/class-subscriber-manager-lite-wctlgm-settings.php
+++ b/includes/class-subscriber-manager-lite-wctlgm-settings.php
@@ -27,6 +27,29 @@ class Subscriber_Manager_Lite_WCTLGM_Settings {
 		add_action( 'admin_menu', array( $this, 'add_settings_page' ) );
 		add_action( 'admin_init', array( $this, 'register_settings' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_subscriber_manager_scripts' ) );
+		add_action( 'init', array( $this, 'migrate_activation_flow_setting' ) );
+	}
+
+	/**
+	 * Migrate activation flow setting from legacy option.
+	 * Runs once on plugin initialization to ensure all users get migrated.
+	 */
+	public function migrate_activation_flow_setting() {
+		if ( get_option( 'wctlgm_activation_flow_migrated', false ) ) {
+			return;
+		}
+
+		$legacy_activation  = get_option( 'wctlgm_force_activation_flow', false );
+		$require_activation = get_option( 'wctlgm_require_activation_flow', false );
+
+		// Only migrate if new option doesn't exist (hasn't been set by user)
+		// and legacy option exists
+		if ( false === $require_activation && false !== $legacy_activation ) {
+			update_option( 'wctlgm_require_activation_flow', $legacy_activation );
+			delete_option( 'wctlgm_force_activation_flow' );
+		}
+
+		update_option( 'wctlgm_activation_flow_migrated', true );
 	}
 
 	/**
@@ -403,16 +426,7 @@ class Subscriber_Manager_Lite_WCTLGM_Settings {
 	}
 
 	public function require_activation_field() {
-		// Ensure upgrades don't break expected activation flow. Since version 1.2.0.
-		$legacy_activation  = get_option( 'wctlgm_force_activation_flow', false );
 		$require_activation = get_option( 'wctlgm_require_activation_flow', false );
-
-		// If the new option doesn't exist but the old one does, migrate it
-		if ( false === $require_activation && false !== $legacy_activation ) {
-			$require_activation = $legacy_activation;
-			update_option( 'wctlgm_require_activation_flow', $require_activation );
-			delete_option( 'wctlgm_force_activation_flow' );
-		}
 
 		echo '<input type="checkbox" name="wctlgm_require_activation_flow" value="1" ' . checked( $require_activation, true, false ) . ' />';
 		echo '<p class="description">' . esc_html__( 'Use the Telegram bot chat to validate users and generate invite links. Not recommended for large or active groups.', 'wctlgm-subscriber-manager-lite' ) . '</p>';

--- a/includes/class-subscriber-manager-lite-wctlgm-settings.php
+++ b/includes/class-subscriber-manager-lite-wctlgm-settings.php
@@ -68,14 +68,14 @@ class Subscriber_Manager_Lite_WCTLGM_Settings {
 						<tr>
 							<td style="padding-top: 0;">
 								<input type="text" name="wctlgm_channels[0][name]" value="<?php echo esc_attr( $channel['name'] ); ?>" />
-								<p class="description"><?php esc_html_e( 'Channel Name', 'wctlgm-subscriber-manager-lite' ); ?></p>
+								<p class="description"><?php esc_html_e( 'Channel/Group Name', 'wctlgm-subscriber-manager-lite' ); ?></p>
 							</td>
 							<td style="padding-top: 0;">
 								<input type="text" name="wctlgm_channels[0][id]" value="<?php echo esc_attr( $channel['id'] ); ?>" />
-								<p class="description"><?php esc_html_e( 'Channel ID', 'wctlgm-subscriber-manager-lite' ); ?></p>
+								<p class="description"><?php esc_html_e( 'Channel/Group ID', 'wctlgm-subscriber-manager-lite' ); ?></p>
 							</td>
 							<td style="vertical-align: top; padding-top: 0;">
-								<button type="button" class="button wctlgm_fetch_channel_id"><?php esc_html_e( 'Get Channel ID', 'wctlgm-subscriber-manager-lite' ); ?></button>
+								<button type="button" class="button wctlgm_fetch_channel_id"><?php esc_html_e( 'Get ID', 'wctlgm-subscriber-manager-lite' ); ?></button>
 							</td>
 						</tr>
 					</tbody>
@@ -194,7 +194,7 @@ class Subscriber_Manager_Lite_WCTLGM_Settings {
 			wp_send_json_success( array( 'channel_id' => $channel_id ) );
 		} else {
 			set_transient( 'wctlgm_telegram_fetch_channel_id_active', true, HOUR_IN_SECONDS );
-			wp_send_json_error( array( 'message' => 'Please post a message in your Telegram channel and then edit it. Then click "Get Channel ID" again.' ) );
+			wp_send_json_error( array( 'message' => 'Please post a message in your Telegram channel or group and then edit it. Then click "Get ID" again.' ) );
 		}
 	}
 
@@ -311,7 +311,7 @@ class Subscriber_Manager_Lite_WCTLGM_Settings {
 
 		add_settings_field(
 			'wctlgm_channels',
-			__( 'Telegram Channels:', 'wctlgm-subscriber-manager-lite' ),
+			__( 'Telegram Channels/Groups:', 'wctlgm-subscriber-manager-lite' ),
 			array( $this, 'channels_field' ),
 			'wctlgm-settings',
 			'wctlgm_settings_section'

--- a/includes/class-subscriber-manager-lite-wctlgm-settings.php
+++ b/includes/class-subscriber-manager-lite-wctlgm-settings.php
@@ -169,6 +169,7 @@ class Subscriber_Manager_Lite_WCTLGM_Settings {
 		$result       = $api_handler->handle_set_webhook_actions( $webhook_url, $secret_token );
 
 		if ( is_wp_error( $result ) ) {
+			// To-do: add logging.
 			$error_message = $result->get_error_message();
 			wp_send_json_error( array( 'message' => $error_message ) );
 		} else {
@@ -235,6 +236,7 @@ class Subscriber_Manager_Lite_WCTLGM_Settings {
 		register_setting( 'wctlgm_settings_group', 'wctlgm_bot_token', array( $this, 'sanitize_text_field' ) );
 		register_setting( 'wctlgm_settings_group', 'wctlgm_bot_url', array( $this, 'sanitize_url' ) );
 		register_setting( 'wctlgm_settings_group', 'wctlgm_allow_external_invites', array( $this, 'sanitize_checkbox' ) );
+		register_setting( 'wctlgm_settings_group', 'wctlgm_require_activation_flow', array( $this, 'sanitize_checkbox' ) );
 		register_setting( 'wctlgm_settings_group', 'wctlgm_channels', array( $this, 'sanitize_channels' ) );
 
 		add_settings_section(
@@ -264,6 +266,14 @@ class Subscriber_Manager_Lite_WCTLGM_Settings {
 			'wctlgm_allow_external_invites',
 			__( 'Allow External Invites', 'wctlgm-subscriber-manager-lite' ),
 			array( $this, 'allow_external_invites_field' ),
+			'wctlgm-settings',
+			'wctlgm_settings_section'
+		);
+
+		add_settings_field(
+			'wctlgm_require_activation_flow',
+			__( 'Require Activation Step', 'wctlgm-subscriber-manager-lite' ),
+			array( $this, 'require_activation_field' ),
 			'wctlgm-settings',
 			'wctlgm_settings_section'
 		);
@@ -344,5 +354,27 @@ class Subscriber_Manager_Lite_WCTLGM_Settings {
 	 */
 	public function channels_field() {
 		$this->custom_channels_input();
+	}
+
+	public function require_activation_field() {
+		// Ensure upgrades don't break expected activation flow. Since version 1.2.0.
+		$legacy_activation  = get_option( 'wctlgm_force_activation_flow', false );
+		$require_activation = get_option( 'wctlgm_require_activation_flow', false );
+
+		// If the new option doesn't exist but the old one does, migrate it
+		if ( false === $require_activation && false !== $legacy_activation ) {
+			$require_activation = $legacy_activation;
+			update_option( 'wctlgm_require_activation_flow', $require_activation );
+			// Clean up old option
+			delete_option( 'wctlgm_force_activation_flow' );
+		}
+
+		// If neither option exists, default to false (activation not required)
+		if ( false === $require_activation ) {
+			$require_activation = false;
+		}
+
+		echo '<input type="checkbox" name="wctlgm_require_activation_flow" value="1" ' . checked( $require_activation, true, false ) . ' />';
+		echo '<p class="description">' . esc_html__( 'If disabled, invite links are sent directly on order completion. The subscriber\'s Telegram ID is captured when they request to join.', 'wctlgm-subscriber-manager-lite' ) . '</p>';
 	}
 }

--- a/includes/class-subscriber-manager-lite-wctlgm-settings.php
+++ b/includes/class-subscriber-manager-lite-wctlgm-settings.php
@@ -81,7 +81,7 @@ class Subscriber_Manager_Lite_WCTLGM_Settings {
 				</table>
 				<?php
 				if ( wctlgm_fs()->is_not_paying() ) {
-					echo wp_kses_post( sprintf( '<em>Need to add multiple channels? <a href="%s">Upgrade to Pro Now!</a></em>', wctlgm_fs()->get_upgrade_url() ) );
+					echo wp_kses_post( sprintf( '<em>Need to add multiple channels or groups? <a href="%s">Upgrade to Pro Now!</a></em>', wctlgm_fs()->get_upgrade_url() ) );
 					echo '</section>';
 				}
 				?>
@@ -92,7 +92,7 @@ class Subscriber_Manager_Lite_WCTLGM_Settings {
 
 	public function wctlgm_add_product_data_tab( $tabs ) {
 		$tabs['telegram'] = array(
-			'label'    => __( 'Telegram Channels', 'wctlgm-subscriber-manager-lite' ),
+			'label'    => __( 'Telegram Access', 'wctlgm-subscriber-manager-lite' ),
 			'target'   => 'telegram_product_data',
 			'class'    => array( 'show_if_simple', 'hide_if_subscription' ),
 			'priority' => 80,
@@ -111,7 +111,7 @@ class Subscriber_Manager_Lite_WCTLGM_Settings {
 		<div id='telegram_product_data' class='panel woocommerce_options_panel'>
 			<div class='options_group'>
 				<p class="form-field">
-					<label for="telegram_channel_ids"><?php esc_html_e( 'Select Channels', 'wctlgm-subscriber-manager-lite' ); ?></label>
+					<label for="telegram_channel_ids"><?php esc_html_e( 'Select Channels/Groups', 'wctlgm-subscriber-manager-lite' ); ?></label>
 					<select class="wc-enhanced-select" multiple="multiple" id="telegram_channel_ids" name="telegram_channel_ids[]" style="width: 50%;">
 						<?php foreach ( $channels as $channel ) : ?>
 							<option value="<?php echo esc_attr( $channel['id'] ); ?>" <?php echo in_array( $channel['id'], $saved_channels, true ) ? 'selected' : ''; ?>>

--- a/includes/class-subscriber-manager-lite-wctlgm-settings.php
+++ b/includes/class-subscriber-manager-lite-wctlgm-settings.php
@@ -11,10 +11,13 @@ namespace Subscriber_Manager_Lite_for_Telegram;
  */
 class Subscriber_Manager_Lite_WCTLGM_Settings {
 
+	private $logger;
+
 	/**
 	 * Constructor for the settings class.
 	 */
 	public function __construct() {
+		$this->logger = new \Subscriber_Manager_Lite_for_Telegram\Subscriber_Manager_Lite_WCTLGM_Logger();
 		add_action( 'wp_ajax_wctlgm_set_webhook', array( $this, 'handle_set_webhook' ) );
 		add_filter( 'woocommerce_product_data_tabs', array( $this, 'wctlgm_add_product_data_tab' ) );
 		add_action( 'woocommerce_product_data_panels', array( $this, 'wctlgm_telegram_product_data_fields' ) );
@@ -169,8 +172,8 @@ class Subscriber_Manager_Lite_WCTLGM_Settings {
 		$result       = $api_handler->handle_set_webhook_actions( $webhook_url, $secret_token );
 
 		if ( is_wp_error( $result ) ) {
-			// To-do: add logging.
 			$error_message = $result->get_error_message();
+			$this->logger->error( __( 'Failed to set webhook: ', 'wctlgm-subscriber-manager-lite' ) . $error_message );
 			wp_send_json_error( array( 'message' => $error_message ) );
 		} else {
 			wp_send_json_success( array( 'message' => 'Webhook set successfully.' ) );

--- a/includes/class-subscriber-manager-lite-wctlgm-settings.php
+++ b/includes/class-subscriber-manager-lite-wctlgm-settings.php
@@ -414,10 +414,6 @@ class Subscriber_Manager_Lite_WCTLGM_Settings {
 			delete_option( 'wctlgm_force_activation_flow' );
 		}
 
-		if ( false === $require_activation ) {
-			$require_activation = false;
-		}
-
 		echo '<input type="checkbox" name="wctlgm_require_activation_flow" value="1" ' . checked( $require_activation, true, false ) . ' />';
 		echo '<p class="description">' . esc_html__( 'Use the Telegram bot chat to validate users and generate invite links. Not recommended for large or active groups.', 'wctlgm-subscriber-manager-lite' ) . '</p>';
 	}

--- a/includes/class-subscriber-manager-lite-wctlgm-settings.php
+++ b/includes/class-subscriber-manager-lite-wctlgm-settings.php
@@ -241,8 +241,8 @@ class Subscriber_Manager_Lite_WCTLGM_Settings {
 			<?php if ( $show_webhook_notification ) : ?>
 			<div class="notice notice-warning is-dismissible" id="wctlgm-webhook-notice">
 				<p>
-					<strong><?php esc_html_e( 'Action Required:', 'wctlgm-subscriber-manager' ); ?></strong>
-					<?php esc_html_e( 'You have changed the "Require Activation Step" setting. Please click the "Set Webhook" button below to update your bot\'s settings.', 'wctlgm-subscriber-manager' ); ?>
+					<strong><?php esc_html_e( 'Action Required:', 'wctlgm-subscriber-manager-lite' ); ?></strong>
+					<?php esc_html_e( 'You have changed the "Require Activation Step" setting. Please click the "Set Webhook" button below to update your bot\'s settings.', 'wctlgm-subscriber-manager-lite' ); ?>
 				</p>
 			</div>
 			<?php endif; ?>

--- a/includes/class-subscriber-manager-lite-wctlgm-settings.php
+++ b/includes/class-subscriber-manager-lite-wctlgm-settings.php
@@ -19,6 +19,7 @@ class Subscriber_Manager_Lite_WCTLGM_Settings {
 	public function __construct() {
 		$this->logger = new \Subscriber_Manager_Lite_for_Telegram\Subscriber_Manager_Lite_WCTLGM_Logger();
 		add_action( 'wp_ajax_wctlgm_set_webhook', array( $this, 'handle_set_webhook' ) );
+		add_action( 'wp_ajax_wctlgm_dismiss_webhook_notice', array( $this, 'handle_dismiss_webhook_notice' ) );
 		add_filter( 'woocommerce_product_data_tabs', array( $this, 'wctlgm_add_product_data_tab' ) );
 		add_action( 'woocommerce_product_data_panels', array( $this, 'wctlgm_telegram_product_data_fields' ) );
 		add_action( 'woocommerce_process_product_meta', array( $this, 'wctlgm_save_telegram_meta_box_data' ) );
@@ -176,6 +177,7 @@ class Subscriber_Manager_Lite_WCTLGM_Settings {
 			$this->logger->error( __( 'Failed to set webhook: ', 'wctlgm-subscriber-manager-lite' ) . $error_message );
 			wp_send_json_error( array( 'message' => $error_message ) );
 		} else {
+			delete_transient( 'wctlgm_activation_flow_changed' );
 			wp_send_json_success( array( 'message' => 'Webhook set successfully.' ) );
 		}
 	}
@@ -197,6 +199,21 @@ class Subscriber_Manager_Lite_WCTLGM_Settings {
 	}
 
 	/**
+	 * Handle dismissing the webhook notification.
+	 */
+	public function handle_dismiss_webhook_notice() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => 'Insufficient permissions' ) );
+			return;
+		}
+
+		delete_transient( 'wctlgm_activation_flow_changed' );
+		wp_send_json_success();
+	}
+
+
+
+	/**
 	 * Add a new settings page under the Settings menu.
 	 */
 	public function add_settings_page() {
@@ -213,12 +230,23 @@ class Subscriber_Manager_Lite_WCTLGM_Settings {
 	 * Display the settings page.
 	 */
 	public function settings_page() {
+		$show_webhook_notification = get_transient( 'wctlgm_activation_flow_changed' );
 		?>
 		<div class="wrap fs-section">
 			<h1><?php esc_html_e( 'Telegram Subscriber Manager Settings', 'wctlgm-subscriber-manager-lite' ); ?></h1>
 			<h2 class="nav-tab-wrapper">
 				<a href="#" class="nav-tab fs-tab nav-tab-active home">Settings</a>
 			</h2>
+
+			<?php if ( $show_webhook_notification ) : ?>
+			<div class="notice notice-warning is-dismissible" id="wctlgm-webhook-notice">
+				<p>
+					<strong><?php esc_html_e( 'Action Required:', 'wctlgm-subscriber-manager' ); ?></strong>
+					<?php esc_html_e( 'You have changed the "Require Activation Step" setting. Please click the "Set Webhook" button below to update your bot\'s settings.', 'wctlgm-subscriber-manager' ); ?>
+				</p>
+			</div>
+			<?php endif; ?>
+			
 			<form method="post" action="options.php">
 				<?php
 				settings_fields( 'wctlgm_settings_group' );
@@ -239,7 +267,7 @@ class Subscriber_Manager_Lite_WCTLGM_Settings {
 		register_setting( 'wctlgm_settings_group', 'wctlgm_bot_token', array( $this, 'sanitize_text_field' ) );
 		register_setting( 'wctlgm_settings_group', 'wctlgm_bot_url', array( $this, 'sanitize_url' ) );
 		register_setting( 'wctlgm_settings_group', 'wctlgm_allow_external_invites', array( $this, 'sanitize_checkbox' ) );
-		register_setting( 'wctlgm_settings_group', 'wctlgm_require_activation_flow', array( $this, 'sanitize_checkbox' ) );
+		register_setting( 'wctlgm_settings_group', 'wctlgm_require_activation_flow', array( $this, 'sanitize_activation_flow' ) );
 		register_setting( 'wctlgm_settings_group', 'wctlgm_channels', array( $this, 'sanitize_channels' ) );
 
 		add_settings_section(
@@ -312,6 +340,21 @@ class Subscriber_Manager_Lite_WCTLGM_Settings {
 	}
 
 	/**
+	 * Sanitize activation flow field and track changes.
+	 */
+	public function sanitize_activation_flow( $input ) {
+		$new_value = isset( $input ) ? true : false;
+		$old_value = get_option( 'wctlgm_require_activation_flow', false );
+
+		// If the value has changed, set a flag to show webhook notification
+		if ( $new_value !== $old_value ) {
+			set_transient( 'wctlgm_activation_flow_changed', true, DAY_IN_SECONDS );
+		}
+
+		return $new_value;
+	}
+
+	/**
 	 * Sanitize channels.
 	 */
 	public function sanitize_channels( $input ) {
@@ -349,7 +392,7 @@ class Subscriber_Manager_Lite_WCTLGM_Settings {
 	public function allow_external_invites_field() {
 		$allow_external_invites = get_option( 'wctlgm_allow_external_invites', false );
 		echo '<input type="checkbox" name="wctlgm_allow_external_invites" value="1" ' . checked( $allow_external_invites, true, false ) . ' />';
-		echo '<p class="description">' . esc_html__( 'When enabled, join requests from external or manually created invite links will skip validation checks.', 'wctlgm-subscriber-manager-lite' ) . '</p>';
+		echo '<p class="description">' . esc_html__( 'When enabled, join requests from external or manually created invite links will skip order validation checks.', 'wctlgm-subscriber-manager-lite' ) . '</p>';
 	}
 
 	/**
@@ -368,16 +411,14 @@ class Subscriber_Manager_Lite_WCTLGM_Settings {
 		if ( false === $require_activation && false !== $legacy_activation ) {
 			$require_activation = $legacy_activation;
 			update_option( 'wctlgm_require_activation_flow', $require_activation );
-			// Clean up old option
 			delete_option( 'wctlgm_force_activation_flow' );
 		}
 
-		// If neither option exists, default to false (activation not required)
 		if ( false === $require_activation ) {
 			$require_activation = false;
 		}
 
 		echo '<input type="checkbox" name="wctlgm_require_activation_flow" value="1" ' . checked( $require_activation, true, false ) . ' />';
-		echo '<p class="description">' . esc_html__( 'If disabled, invite links are sent directly on order completion. The subscriber\'s Telegram ID is captured when they request to join.', 'wctlgm-subscriber-manager-lite' ) . '</p>';
+		echo '<p class="description">' . esc_html__( 'Use the Telegram bot chat to validate users and generate invite links. Not recommended for large or active groups.', 'wctlgm-subscriber-manager-lite' ) . '</p>';
 	}
 }

--- a/includes/class-subscriber-manager-lite-wctlgm-subscriptions-handler.php
+++ b/includes/class-subscriber-manager-lite-wctlgm-subscriptions-handler.php
@@ -37,9 +37,20 @@ class Subscriber_Manager_Lite_WCTLGM_Subscriptions_Handler {
 	public function is_join_request_valid( $user_id, $invite_link ) {
 		$order = $this->find_order_by( '_channel_invite', sanitize_url( $invite_link ) );
 		if ( $order ) {
-			$order_id         = $order->get_id();
-			$telegram_user_id = $order->get_meta( '_telegram_user_id', true );
-			if ( (string) $telegram_user_id === (string) $user_id ) {
+			// Ensure order is in a valid status (completed or processing)
+			if ( ! in_array( $order->get_status(), array( 'completed', 'processing' ), true ) ) {
+				return false;
+			}
+
+			$order_id           = $order->get_id();
+			$telegram_user_id   = $order->get_meta( '_telegram_user_id', true );
+			$require_activation = get_option( 'wctlgm_require_activation_flow', true );
+			if ( $require_activation ) {
+				return (string) $telegram_user_id === (string) $user_id;
+			} else {
+				// Activation disabled - capture the user ID and approve
+				$order->update_meta_data( '_telegram_user_id', sanitize_text_field( $user_id ) );
+				$order->save();
 				return true;
 			}
 		}
@@ -70,7 +81,7 @@ class Subscriber_Manager_Lite_WCTLGM_Subscriptions_Handler {
 		return null;
 	}
 
-	private function get_channel_invites( $order ) {
+	public function get_channel_invites( $order ) {
 		$invites = array();
 
 		foreach ( $order->get_items() as $item_id => $item ) {

--- a/includes/class-subscriber-manager-lite-wctlgm-subscriptions-handler.php
+++ b/includes/class-subscriber-manager-lite-wctlgm-subscriptions-handler.php
@@ -90,12 +90,25 @@ class Subscriber_Manager_Lite_WCTLGM_Subscriptions_Handler {
 
 			if ( ! empty( $channel_ids ) ) {
 				foreach ( $channel_ids as $channel_id ) {
-					$invite_link = $this->api_handler->generate_invite_link( $channel_id );
-					if ( $invite_link && ! is_wp_error( $invite_link ) ) {
+
+					// Check if invite link already exists for this order and channel
+					$existing_invite = $this->get_existing_invite_for_channel( $order );
+
+					if ( $existing_invite ) {
+						// Use existing invite link
 						$invites[] = array(
 							'name'        => $this->get_channel_name_by_id( $channel_id ),
-							'invite_link' => $invite_link,
+							'invite_link' => $existing_invite,
 						);
+					} else {
+						// Generate new invite link only if none exists
+						$invite_link = $this->api_handler->generate_invite_link( $channel_id );
+						if ( $invite_link && ! is_wp_error( $invite_link ) ) {
+							$invites[] = array(
+								'name'        => $this->get_channel_name_by_id( $channel_id ),
+								'invite_link' => $invite_link,
+							);
+						}
 					}
 				}
 			}
@@ -130,6 +143,28 @@ class Subscriber_Manager_Lite_WCTLGM_Subscriptions_Handler {
 				return $channel['name'];
 			}
 		}
+
+		return null;
+	}
+
+	/**
+	 * Check if an invite link already exists for a specific order and channel.
+	 *
+	 * @param WC_Order $order The order object.
+	 * @param string   $channel_id The channel ID to check for.
+	 * @return string|null The existing invite link or null if not found.
+	 */
+	private function get_existing_invite_for_channel( $order ) {
+		$existing_invite = $order->get_meta( '_channel_invite', true );
+
+		if ( empty( $existing_invite ) ) {
+			return null;
+		} else {
+			return $existing_invite;
+		}
+
+		// To-do: Pro version is more complex as we don't currently store the channel ID against the invite link.
+		// Maybe we index the invite link meta key with the channel ID.
 
 		return null;
 	}

--- a/includes/class-subscriber-manager-lite-wctlgm-subscriptions-handler.php
+++ b/includes/class-subscriber-manager-lite-wctlgm-subscriptions-handler.php
@@ -34,7 +34,7 @@ class Subscriber_Manager_Lite_WCTLGM_Subscriptions_Handler {
 		return false;
 	}
 
-	public function is_join_request_valid( $user_id, $invite_link ) {
+	public function is_join_request_valid( $user_id, $invite_link, $allow_external_invites = false ) {
 		$order = $this->find_order_by_invite_link( sanitize_url( $invite_link ) );
 		if ( $order ) {
 			// Ensure order is in a valid status (completed or processing)
@@ -54,6 +54,13 @@ class Subscriber_Manager_Lite_WCTLGM_Subscriptions_Handler {
 				return true;
 			}
 		}
+
+		if ( $allow_external_invites ) {
+			// To-do: This is where we would add external users for 2.0.
+			$this->logger->info( __( 'External invite link approved: ', 'wctlgm-subscriber-manager' ) . $user_id . ' - ' . $invite_link );
+			return true;
+		}
+
 		return false;
 	}
 

--- a/includes/class-subscriber-manager-lite-wctlgm-subscriptions-handler.php
+++ b/includes/class-subscriber-manager-lite-wctlgm-subscriptions-handler.php
@@ -26,7 +26,7 @@ class Subscriber_Manager_Lite_WCTLGM_Subscriptions_Handler {
 			$response        = $this->get_channel_invites( $order );
 			$channel_invites = $response['channels'];
 			foreach ( $channel_invites as $invite ) {
-				$order->add_meta_data( '_channel_invite', sanitize_url( $invite['invite_link'] ) );
+				$order->add_meta_data( '_channel_invite_' . $invite['channel_id'], sanitize_url( $invite['invite_link'] ) );
 			}
 			$order->save();
 			return array( $response, $order_id );
@@ -35,7 +35,7 @@ class Subscriber_Manager_Lite_WCTLGM_Subscriptions_Handler {
 	}
 
 	public function is_join_request_valid( $user_id, $invite_link ) {
-		$order = $this->find_order_by( '_channel_invite', sanitize_url( $invite_link ) );
+		$order = $this->find_order_by_invite_link( '_channel_invite', sanitize_url( $invite_link ) );
 		if ( $order ) {
 			// Ensure order is in a valid status (completed or processing)
 			if ( ! in_array( $order->get_status(), array( 'completed', 'processing' ), true ) ) {
@@ -57,14 +57,14 @@ class Subscriber_Manager_Lite_WCTLGM_Subscriptions_Handler {
 		return false;
 	}
 
-	private function find_order_by( $meta_key, $meta_value ) {
+	private function find_order_by( $meta_key, $meta_value, $compare = '=' ) {
 		$orders = wc_get_orders(
 			array(
 				'meta_query' => array(
 					array(
 						'key'     => $meta_key,
 						'value'   => $meta_value,
-						'compare' => '=',
+						'compare' => $compare,
 					),
 				),
 			)
@@ -81,6 +81,31 @@ class Subscriber_Manager_Lite_WCTLGM_Subscriptions_Handler {
 		return null;
 	}
 
+	/**
+	 * Find order by invite link, searching through all indexed channel invite meta keys.
+	 *
+	 * @param string $invite_link The invite link to search for.
+	 * @return WC_Order|null The order if found, null otherwise.
+	 */
+	private function find_order_by_invite_link( $meta_key, $invite_link, $compare = 'LIKE' ) {
+		// Get all orders with any _channel_invite_* meta key
+		$orders = $this->find_order_by( $meta_key, $invite_link, $compare );
+
+		foreach ( $orders as $order ) {
+			// Get all meta data for this order
+			$meta_data = $order->get_meta_data();
+			foreach ( $meta_data as $meta ) {
+				$meta_key   = $meta->get_data()['key'];
+				$meta_value = $meta->get_data()['value'];// Check if this is a channel invite meta and matches our invite link
+				if ( strpos( $meta_key, '_channel_invite_' ) === 0 && $meta_value === $invite_link ) {
+					return $order;
+				}
+			}
+		}
+
+		return null;
+	}
+
 	public function get_channel_invites( $order ) {
 		$invites = array();
 
@@ -92,11 +117,12 @@ class Subscriber_Manager_Lite_WCTLGM_Subscriptions_Handler {
 				foreach ( $channel_ids as $channel_id ) {
 
 					// Check if invite link already exists for this order and channel
-					$existing_invite = $this->get_existing_invite_for_channel( $order );
+					$existing_invite = $this->get_existing_invite_for_channel( $order, $channel_id );
 
 					if ( $existing_invite ) {
 						// Use existing invite link
 						$invites[] = array(
+							'channel_id'  => $channel_id,
 							'name'        => $this->get_channel_name_by_id( $channel_id ),
 							'invite_link' => $existing_invite,
 						);
@@ -105,6 +131,7 @@ class Subscriber_Manager_Lite_WCTLGM_Subscriptions_Handler {
 						$invite_link = $this->api_handler->generate_invite_link( $channel_id );
 						if ( $invite_link && ! is_wp_error( $invite_link ) ) {
 							$invites[] = array(
+								'channel_id'  => $channel_id,
 								'name'        => $this->get_channel_name_by_id( $channel_id ),
 								'invite_link' => $invite_link,
 							);
@@ -154,18 +181,13 @@ class Subscriber_Manager_Lite_WCTLGM_Subscriptions_Handler {
 	 * @param string   $channel_id The channel ID to check for.
 	 * @return string|null The existing invite link or null if not found.
 	 */
-	private function get_existing_invite_for_channel( $order ) {
-		$existing_invite = $order->get_meta( '_channel_invite', true );
+	private function get_existing_invite_for_channel( $order, $channel_id ) {
+		$existing_invite = $order->get_meta( '_channel_invite_' . $channel_id, true );
 
 		if ( empty( $existing_invite ) ) {
 			return null;
-		} else {
-			return $existing_invite;
 		}
 
-		// To-do: Pro version is more complex as we don't currently store the channel ID against the invite link.
-		// Maybe we index the invite link meta key with the channel ID.
-
-		return null;
+		return $existing_invite;
 	}
 }

--- a/includes/class-subscriber-manager-lite-wctlgm-subscriptions-handler.php
+++ b/includes/class-subscriber-manager-lite-wctlgm-subscriptions-handler.php
@@ -12,14 +12,16 @@ namespace Subscriber_Manager_Lite_for_Telegram;
 class Subscriber_Manager_Lite_WCTLGM_Subscriptions_Handler {
 
 	private $api_handler;
+	private $logger;
 
 	public function __construct() {
 		$this->api_handler = new \Subscriber_Manager_Lite_for_Telegram\Subscriber_Manager_Lite_WCTLGM_API_Handler();
+		$this->logger      = new \Subscriber_Manager_Lite_for_Telegram\Subscriber_Manager_Lite_WCTLGM_Logger();
 	}
 
 	public function process_activation_code( $code, $telegram_user_id ) {
 		$order = $this->find_order_by( '_activation_code', sanitize_text_field( $code ) );
-		if ( $order ) {
+		if ( $order && in_array( $order->get_status(), array( 'completed', 'processing' ), true ) ) {
 			$order_id = $order->get_id();
 			$order->update_meta_data( '_telegram_user_id', sanitize_text_field( $telegram_user_id ) );
 			$order->delete_meta_data( '_activation_code', sanitize_text_field( $code ) );
@@ -34,8 +36,8 @@ class Subscriber_Manager_Lite_WCTLGM_Subscriptions_Handler {
 		return false;
 	}
 
-	public function is_join_request_valid( $user_id, $invite_link, $allow_external_invites = false ) {
-		$order = $this->find_order_by_invite_link( sanitize_url( $invite_link ) );
+	public function is_join_request_valid( $user_id, $invite_link, $chat_id, $allow_external_invites = false ) {
+		$order = $this->find_order_by_invite_link( sanitize_url( $invite_link ), $chat_id );
 		if ( $order ) {
 			// Ensure order is in a valid status (completed or processing)
 			if ( ! in_array( $order->get_status(), array( 'completed', 'processing' ), true ) ) {
@@ -94,31 +96,10 @@ class Subscriber_Manager_Lite_WCTLGM_Subscriptions_Handler {
 	 * @param string $invite_link The invite link to search for.
 	 * @return WC_Order|null The order if found, null otherwise.
 	 */
-	private function find_order_by_invite_link( $invite_link ) {
-		// Get all orders with any _channel_invite_* meta key
-		$orders = wc_get_orders(
-			array(
-				'meta_query' => array(
-					array(
-						'key'     => '_channel_invite_',
-						'value'   => '',
-						'compare' => 'LIKE',
-					),
-				),
-			)
-		);
-
-		foreach ( $orders as $order ) {
-			// Get all meta data for this order
-			$meta_data = $order->get_meta_data();
-			foreach ( $meta_data as $meta ) {
-				$meta_key   = $meta->get_data()['key'];
-				$meta_value = $meta->get_data()['value'];
-				// Check if this is a channel invite meta and matches our invite link
-				if ( strpos( $meta_key, '_channel_invite_' ) === 0 && $meta_value === $invite_link ) {
-					return $order;
-				}
-			}
+	private function find_order_by_invite_link( $invite_link, $chat_id = null ) {
+		if ( $chat_id ) {
+			$meta_key = '_channel_invite_' . $chat_id;
+			return $this->find_order_by( $meta_key, $invite_link );
 		}
 
 		return null;

--- a/includes/class-subscriber-manager-lite-wctlgm-subscriptions-handler.php
+++ b/includes/class-subscriber-manager-lite-wctlgm-subscriptions-handler.php
@@ -46,7 +46,7 @@ class Subscriber_Manager_Lite_WCTLGM_Subscriptions_Handler {
 
 			$order_id           = $order->get_id();
 			$telegram_user_id   = $order->get_meta( '_telegram_user_id', true );
-			$require_activation = get_option( 'wctlgm_require_activation_flow', true );
+			$require_activation = get_option( 'wctlgm_require_activation_flow', false );
 			if ( $require_activation ) {
 				return (string) $telegram_user_id === (string) $user_id;
 			} else {

--- a/includes/class-subscriber-manager-lite-wctlgm-subscriptions-handler.php
+++ b/includes/class-subscriber-manager-lite-wctlgm-subscriptions-handler.php
@@ -35,7 +35,7 @@ class Subscriber_Manager_Lite_WCTLGM_Subscriptions_Handler {
 	}
 
 	public function is_join_request_valid( $user_id, $invite_link ) {
-		$order = $this->find_order_by_invite_link( '_channel_invite', sanitize_url( $invite_link ) );
+		$order = $this->find_order_by_invite_link( sanitize_url( $invite_link ) );
 		if ( $order ) {
 			// Ensure order is in a valid status (completed or processing)
 			if ( ! in_array( $order->get_status(), array( 'completed', 'processing' ), true ) ) {
@@ -87,16 +87,27 @@ class Subscriber_Manager_Lite_WCTLGM_Subscriptions_Handler {
 	 * @param string $invite_link The invite link to search for.
 	 * @return WC_Order|null The order if found, null otherwise.
 	 */
-	private function find_order_by_invite_link( $meta_key, $invite_link, $compare = 'LIKE' ) {
+	private function find_order_by_invite_link( $invite_link ) {
 		// Get all orders with any _channel_invite_* meta key
-		$orders = $this->find_order_by( $meta_key, $invite_link, $compare );
+		$orders = wc_get_orders(
+			array(
+				'meta_query' => array(
+					array(
+						'key'     => '_channel_invite_',
+						'value'   => '',
+						'compare' => 'LIKE',
+					),
+				),
+			)
+		);
 
 		foreach ( $orders as $order ) {
 			// Get all meta data for this order
 			$meta_data = $order->get_meta_data();
 			foreach ( $meta_data as $meta ) {
 				$meta_key   = $meta->get_data()['key'];
-				$meta_value = $meta->get_data()['value'];// Check if this is a channel invite meta and matches our invite link
+				$meta_value = $meta->get_data()['value'];
+				// Check if this is a channel invite meta and matches our invite link
 				if ( strpos( $meta_key, '_channel_invite_' ) === 0 && $meta_value === $invite_link ) {
 					return $order;
 				}

--- a/includes/class-subscriber-manager-lite-wctlgm-subscriptions-handler.php
+++ b/includes/class-subscriber-manager-lite-wctlgm-subscriptions-handler.php
@@ -51,6 +51,20 @@ class Subscriber_Manager_Lite_WCTLGM_Subscriptions_Handler {
 				return (string) $telegram_user_id === (string) $user_id;
 			} else {
 				// Activation disabled - capture the user ID and approve
+				// Check if user ID already exists and log if overwriting
+				if ( ! empty( $telegram_user_id ) && $telegram_user_id !== $user_id ) {
+					$this->logger->warning(
+						sprintf(
+							'Attempted User ID overwrite in order %1$d: %2$s -> %3$s',
+							$order_id,
+							$telegram_user_id,
+							$user_id
+						)
+					);
+					return false;
+				}
+
+				// Only update if no user ID exists
 				$order->update_meta_data( '_telegram_user_id', sanitize_text_field( $user_id ) );
 				$order->save();
 				return true;
@@ -59,7 +73,7 @@ class Subscriber_Manager_Lite_WCTLGM_Subscriptions_Handler {
 
 		if ( $allow_external_invites ) {
 			// To-do: This is where we would add external users for 2.0.
-			$this->logger->info( __( 'External invite link approved: ', 'wctlgm-subscriber-manager' ) . $user_id . ' - ' . $invite_link );
+			$this->logger->info( __( 'External invite link approved: ', 'wctlgm-subscriber-manager-lite' ) . $user_id . ' - ' . $invite_link );
 			return true;
 		}
 

--- a/includes/class-subscriber-manager-lite-wctlgm.php
+++ b/includes/class-subscriber-manager-lite-wctlgm.php
@@ -37,6 +37,13 @@ class Subscriber_Manager_Lite_WCTLGM {
 	 * Defines the admin settings page.
 	 */
 	private function define_admin_settings() {
+		add_action( 'init', array( $this, 'init_settings' ) );
+	}
+
+	/**
+	 * Initialize settings.
+	 */
+	public function init_settings() {
 		new \Subscriber_Manager_Lite_for_Telegram\Subscriber_Manager_Lite_WCTLGM_Settings();
 	}
 

--- a/includes/emails/class-subscriber-manager-lite-wctlgm-activation-email.php
+++ b/includes/emails/class-subscriber-manager-lite-wctlgm-activation-email.php
@@ -7,9 +7,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Telegram Channel Activation Email
+ * Telegram Post-Activation Email. Used when the activation checkout flow is enabled.
  *
- * An email sent to the customer when their Telegram channel access is activated.
+ * An email sent to the customer with their Telegram invite links after their Telegram access is activated.
  *
  * @class       Subscriber_Manager_Lite_WCTLGM_Activation_Email
  * @version     1.2.0
@@ -31,8 +31,8 @@ class Subscriber_Manager_Lite_WCTLGM_Activation_Email extends \WC_Email {
 	public function __construct() {
 		$this->id             = 'wctlgm_activation';
 		$this->customer_email = true;
-		$this->title          = __( 'Telegram Channel Activation', 'wctlgm-subscriber-manager-lite' );
-		$this->description    = __( 'This email is sent to customers when their Telegram channel access is activated.', 'wctlgm-subscriber-manager-lite' );
+		$this->title          = __( 'Telegram Post-Activation Invite Links', 'wctlgm-subscriber-manager-lite' );
+		$this->description    = __( 'This email is sent to customers when their Telegram access is activated, and includes their invite links. Used when the activation checkout flow is enabled.', 'wctlgm-subscriber-manager-lite' );
 		$this->template_html  = 'emails/telegram-channel-activation.php';
 		$this->template_plain = 'emails/plain/telegram-channel-activation.php';
 		$this->template_base  = WCTLGM_SML_PLUGIN_DIR . 'templates/';
@@ -47,7 +47,7 @@ class Subscriber_Manager_Lite_WCTLGM_Activation_Email extends \WC_Email {
 	 * @return string
 	 */
 	public function get_default_subject() {
-		return __( 'Your Subscription Activation Details', 'wctlgm-subscriber-manager-lite' );
+		return __( 'Your Telegram Invite Links', 'wctlgm-subscriber-manager-lite' );
 	}
 
 	/**
@@ -56,7 +56,7 @@ class Subscriber_Manager_Lite_WCTLGM_Activation_Email extends \WC_Email {
 	 * @return string
 	 */
 	public function get_default_heading() {
-		return __( 'Your Telegram Channel Access', 'wctlgm-subscriber-manager-lite' );
+		return __( 'Your Telegram Invite Links', 'wctlgm-subscriber-manager-lite' );
 	}
 
 	/**

--- a/includes/emails/class-subscriber-manager-lite-wctlgm-activation-email.php
+++ b/includes/emails/class-subscriber-manager-lite-wctlgm-activation-email.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * An email sent to the customer with their Telegram invite links after their Telegram access is activated.
  *
  * @class       Subscriber_Manager_Lite_WCTLGM_Activation_Email
- * @version     1.2.0
+ * @version     1.4.0
  * @extends     WC_Email
  * @since       1.2.0
  */

--- a/includes/emails/class-subscriber-manager-lite-wctlgm-invite-links-email.php
+++ b/includes/emails/class-subscriber-manager-lite-wctlgm-invite-links-email.php
@@ -7,9 +7,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Telegram Channel Invite Links Email
+ * Telegram Invite Links Email. Used when the activation flow is disabled.
  *
- * An email sent to the customer with their Telegram channel invite links when activation is disabled.
+ * An email sent to the customer with their Telegram invite links when activation is disabled.
  *
  * @class       Subscriber_Manager_Lite_WCTLGM_Invite_Links_Email
  * @version     1.2.0
@@ -31,8 +31,8 @@ class Subscriber_Manager_Lite_WCTLGM_Invite_Links_Email extends \WC_Email {
 	public function __construct() {
 		$this->id             = 'wctlgm_invite_links';
 		$this->customer_email = true;
-		$this->title          = __( 'Telegram Channel Invite Links', 'wctlgm-subscriber-manager-lite' );
-		$this->description    = __( 'This email is sent to customers with their Telegram channel invite links when activation is disabled.', 'wctlgm-subscriber-manager-lite' );
+		$this->title          = __( 'Telegram Invite Links', 'wctlgm-subscriber-manager-lite' );
+		$this->description    = __( 'This email is sent to customers with their Telegram invite links when activation flow is disabled.', 'wctlgm-subscriber-manager-lite' );
 		$this->template_html  = 'emails/telegram-channel-invite-links.php';
 		$this->template_plain = 'emails/plain/telegram-channel-invite-links.php';
 		$this->template_base  = WCTLGM_SML_PLUGIN_DIR . 'templates/';
@@ -47,7 +47,7 @@ class Subscriber_Manager_Lite_WCTLGM_Invite_Links_Email extends \WC_Email {
 	 * @return string
 	 */
 	public function get_default_subject() {
-		return __( 'Your Telegram Channel Access - Order #{order_number}', 'wctlgm-subscriber-manager-lite' );
+		return __( 'Your Telegram Invite Links', 'wctlgm-subscriber-manager-lite' );
 	}
 
 	/**
@@ -56,7 +56,7 @@ class Subscriber_Manager_Lite_WCTLGM_Invite_Links_Email extends \WC_Email {
 	 * @return string
 	 */
 	public function get_default_heading() {
-		return __( 'Your Telegram Channel Access', 'wctlgm-subscriber-manager-lite' );
+		return __( 'Your Telegram Invite Links', 'wctlgm-subscriber-manager-lite' );
 	}
 
 	/**

--- a/includes/emails/class-subscriber-manager-lite-wctlgm-invite-links-email.php
+++ b/includes/emails/class-subscriber-manager-lite-wctlgm-invite-links-email.php
@@ -12,9 +12,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  * An email sent to the customer with their Telegram invite links when activation is disabled.
  *
  * @class       Subscriber_Manager_Lite_WCTLGM_Invite_Links_Email
- * @version     1.2.0
+ * @version     1.4.0
  * @extends     WC_Email
- * @since       1.2.0
+ * @since       1.4.0
  */
 class Subscriber_Manager_Lite_WCTLGM_Invite_Links_Email extends \WC_Email {
 

--- a/includes/emails/class-subscriber-manager-lite-wctlgm-invite-links-email.php
+++ b/includes/emails/class-subscriber-manager-lite-wctlgm-invite-links-email.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Subscriber_Manager_Lite_for_Telegram;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Telegram Channel Invite Links Email
+ *
+ * An email sent to the customer with their Telegram channel invite links when activation is disabled.
+ *
+ * @class       Subscriber_Manager_Lite_WCTLGM_Invite_Links_Email
+ * @version     1.2.0
+ * @extends     WC_Email
+ * @since       1.2.0
+ */
+class Subscriber_Manager_Lite_WCTLGM_Invite_Links_Email extends \WC_Email {
+
+	/**
+	 * Channel invites data.
+	 *
+	 * @var array
+	 */
+	public $invites;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->id             = 'wctlgm_invite_links';
+		$this->customer_email = true;
+		$this->title          = __( 'Telegram Channel Invite Links', 'wctlgm-subscriber-manager-lite' );
+		$this->description    = __( 'This email is sent to customers with their Telegram channel invite links when activation is disabled.', 'wctlgm-subscriber-manager-lite' );
+		$this->template_html  = 'emails/telegram-channel-invite-links.php';
+		$this->template_plain = 'emails/plain/telegram-channel-invite-links.php';
+		$this->template_base  = WCTLGM_SML_PLUGIN_DIR . 'templates/';
+
+		// Call parent constructor
+		parent::__construct();
+	}
+
+	/**
+	 * Get email subject.
+	 *
+	 * @return string
+	 */
+	public function get_default_subject() {
+		return __( 'Your Telegram Channel Access - Order #{order_number}', 'wctlgm-subscriber-manager-lite' );
+	}
+
+	/**
+	 * Get email heading.
+	 *
+	 * @return string
+	 */
+	public function get_default_heading() {
+		return __( 'Your Telegram Channel Access', 'wctlgm-subscriber-manager-lite' );
+	}
+
+	/**
+	 * Trigger the sending of this email.
+	 *
+	 * @param int $order_id The order ID.
+	 * @param array $invites The channel invites data.
+	 */
+	public function trigger( $order_id, $invites ) {
+		$this->setup_locale();
+
+		if ( $order_id ) {
+			$this->object = \wc_get_order( $order_id );
+			if ( is_a( $this->object, 'WC_Order' ) ) {
+				$this->recipient = $this->object->get_billing_email();
+				$this->invites   = $invites;
+			}
+		}
+
+		if ( $this->is_enabled() && $this->get_recipient() ) {
+			$this->send( $this->get_recipient(), $this->get_subject(), $this->get_content(), $this->get_headers(), $this->get_attachments() );
+		}
+
+		$this->restore_locale();
+	}
+
+	/**
+	 * Get content html.
+	 *
+	 * @return string
+	 */
+	public function get_content_html() {
+		return \wc_get_template_html(
+			$this->template_html,
+			array(
+				'order'              => $this->object,
+				'invites'            => $this->invites,
+				'email_heading'      => $this->get_heading(),
+				'additional_content' => $this->get_additional_content(),
+				'sent_to_admin'      => false,
+				'plain_text'         => false,
+				'email'              => $this,
+			),
+			'',
+			$this->template_base
+		);
+	}
+
+	/**
+	 * Get content plain.
+	 *
+	 * @return string
+	 */
+	public function get_content_plain() {
+		return \wc_get_template_html(
+			$this->template_plain,
+			array(
+				'order'              => $this->object,
+				'invites'            => $this->invites,
+				'email_heading'      => $this->get_heading(),
+				'additional_content' => $this->get_additional_content(),
+				'sent_to_admin'      => false,
+				'plain_text'         => true,
+				'email'              => $this,
+			),
+			'',
+			$this->template_base
+		);
+	}
+}

--- a/templates/emails/plain/telegram-channel-activation.php
+++ b/templates/emails/plain/telegram-channel-activation.php
@@ -5,7 +5,7 @@
  * This template can be overridden by copying it to yourtheme/woocommerce/emails/plain/telegram-channel-activation.php.
  *
  * @package WooCommerce\Templates\Emails\Plain
- * @version 1.2.0
+ * @version 1.4.0
  *
  * @since 1.2.0
  */
@@ -16,7 +16,7 @@ echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n";
 echo esc_html( wp_strip_all_tags( $email_heading ) );
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
-echo esc_html__( 'Thank you for activating your subscription. Below are your invitation links:', 'wctlgm-subscriber-manager-lite' ) . "\n\n";
+echo esc_html__( 'Thank you for activating your subscription. Below are your invite links:', 'wctlgm-subscriber-manager-lite' ) . "\n\n";
 
 if ( ! empty( $invites ) ) {
 	foreach ( $invites as $invite ) {

--- a/templates/emails/plain/telegram-channel-activation.php
+++ b/templates/emails/plain/telegram-channel-activation.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Telegram Channel Activation email (plain text)
+ * Telegram Channel Post-Activation email with invitation links (plain text)
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/emails/plain/telegram-channel-activation.php.
  *
@@ -16,7 +16,7 @@ echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n";
 echo esc_html( wp_strip_all_tags( $email_heading ) );
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
-echo esc_html__( 'Thank you for activating your subscription. Below are your private channel invite links:', 'wctlgm-subscriber-manager-lite' ) . "\n\n";
+echo esc_html__( 'Thank you for activating your subscription. Below are your invitation links:', 'wctlgm-subscriber-manager-lite' ) . "\n\n";
 
 if ( ! empty( $invites ) ) {
 	foreach ( $invites as $invite ) {

--- a/templates/emails/plain/telegram-channel-invite-links.php
+++ b/templates/emails/plain/telegram-channel-invite-links.php
@@ -5,9 +5,9 @@
  * This template can be overridden by copying it to yourtheme/woocommerce/emails/plain/telegram-channel-invite-links.php.
  *
  * @package WooCommerce\Templates\Emails\Plain
- * @version 1.2.0
+ * @version 1.4.0
  *
- * @since 1.2.0
+ * @since 1.4.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/templates/emails/plain/telegram-channel-invite-links.php
+++ b/templates/emails/plain/telegram-channel-invite-links.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Telegram Channel Invite Links email (plain text)
+ * Telegram Channel Invite Links email (plain text). Used when the activation flow is disabled.
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/emails/plain/telegram-channel-invite-links.php.
  *
@@ -16,7 +16,7 @@ echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n";
 echo esc_html( wp_strip_all_tags( $email_heading ) );
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
-echo esc_html__( 'Thank you for your purchase! Below are your private channel invite links:', 'wctlgm-subscriber-manager-lite' ) . "\n\n";
+echo esc_html__( 'Thank you for your purchase! Below are your invite links:', 'wctlgm-subscriber-manager-lite' ) . "\n\n";
 
 if ( ! empty( $invites ) ) {
 	foreach ( $invites as $invite ) {
@@ -25,7 +25,7 @@ if ( ! empty( $invites ) ) {
 	}
 }
 
-echo esc_html__( 'These invite links are private and should not be shared with others.', 'wctlgm-subscriber-manager-lite' ) . "\n\n";
+echo esc_html__( 'These invite links are one-time use only and should not be shared with others.', 'wctlgm-subscriber-manager-lite' ) . "\n\n";
 
 echo esc_html__( 'If you have any issues or questions, please contact support.', 'wctlgm-subscriber-manager-lite' ) . "\n\n";
 

--- a/templates/emails/plain/telegram-channel-invite-links.php
+++ b/templates/emails/plain/telegram-channel-invite-links.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Telegram Channel Invite Links email (plain text)
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/emails/plain/telegram-channel-invite-links.php.
+ *
+ * @package WooCommerce\Templates\Emails\Plain
+ * @version 1.2.0
+ *
+ * @since 1.2.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n";
+echo esc_html( wp_strip_all_tags( $email_heading ) );
+echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
+
+echo esc_html__( 'Thank you for your purchase! Below are your private channel invite links:', 'wctlgm-subscriber-manager-lite' ) . "\n\n";
+
+if ( ! empty( $invites ) ) {
+	foreach ( $invites as $invite ) {
+		echo esc_html( $invite['name'] ) . ":\n";
+		echo esc_url( $invite['invite_link'] ) . "\n\n";
+	}
+}
+
+echo esc_html__( 'These invite links are private and should not be shared with others.', 'wctlgm-subscriber-manager-lite' ) . "\n\n";
+
+echo esc_html__( 'If you have any issues or questions, please contact support.', 'wctlgm-subscriber-manager-lite' ) . "\n\n";
+
+/**
+ * Show user-defined additional content - this is set in each email's settings.
+ */
+if ( $additional_content ) {
+	echo esc_html( wp_strip_all_tags( wptexturize( $additional_content ) ) );
+	echo "\n\n----------------------------------------\n\n";
+}
+
+/*
+ * @hooked WC_Emails::email_footer() Output the email footer
+ */
+do_action( 'woocommerce_email_footer', $email );

--- a/templates/emails/telegram-channel-activation.php
+++ b/templates/emails/telegram-channel-activation.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Telegram Channel Activation email
+ * Telegram Channel Post-Activation email with invitation links.
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/emails/telegram-channel-activation.php.
  *
@@ -18,7 +18,7 @@ defined( 'ABSPATH' ) || exit;
 do_action( 'woocommerce_email_header', $email_heading, $email );
 ?>
 
-<p><?php esc_html_e( 'Thank you for activating your subscription. Below are your private channel invite links:', 'wctlgm-subscriber-manager-lite' ); ?></p>
+<p><?php esc_html_e( 'Thank you for activating your subscription. Below are your invitation links:', 'wctlgm-subscriber-manager-lite' ); ?></p>
 
 <?php if ( ! empty( $invites ) ) : ?>
 	<?php foreach ( $invites as $invite ) : ?>

--- a/templates/emails/telegram-channel-activation.php
+++ b/templates/emails/telegram-channel-activation.php
@@ -5,7 +5,7 @@
  * This template can be overridden by copying it to yourtheme/woocommerce/emails/telegram-channel-activation.php.
  *
  * @package WooCommerce\Templates\Emails
- * @version 1.2.0
+ * @version 1.4.0
  *
  * @since 1.2.0
  */

--- a/templates/emails/telegram-channel-activation.php
+++ b/templates/emails/telegram-channel-activation.php
@@ -23,8 +23,8 @@ do_action( 'woocommerce_email_header', $email_heading, $email );
 <?php if ( ! empty( $invites ) ) : ?>
 	<?php foreach ( $invites as $invite ) : ?>
 		<div style="margin-bottom: 10px;">
-			<span style="font-weight: bold;"><?php echo esc_html( $invite['name'] ); ?>:</span>
-			<a href="<?php echo esc_url( $invite['invite_link'] ); ?>" style="color: <?php echo esc_attr( $email->get_option( 'link_color', '#96588a' ) ); ?>;"><?php esc_html_e( 'Join Channel', 'wctlgm-subscriber-manager-lite' ); ?></a>
+			<span style="font-weight: bold;"><?php echo esc_html( $invite['name'] ); ?>:</span><br>
+			<a href="<?php echo esc_url( $invite['invite_link'] ); ?>" style="color: <?php echo esc_attr( $email->get_option( 'link_color', '#96588a' ) ); ?>; text-decoration: underline;"><?php echo esc_url( $invite['invite_link'] ); ?></a>
 		</div>
 	<?php endforeach; ?>
 <?php endif; ?>

--- a/templates/emails/telegram-channel-activation.php
+++ b/templates/emails/telegram-channel-activation.php
@@ -18,7 +18,7 @@ defined( 'ABSPATH' ) || exit;
 do_action( 'woocommerce_email_header', $email_heading, $email );
 ?>
 
-<p><?php esc_html_e( 'Thank you for activating your subscription. Below are your invitation links:', 'wctlgm-subscriber-manager-lite' ); ?></p>
+<p><?php esc_html_e( 'Thank you for activating your subscription. Below are your invite links:', 'wctlgm-subscriber-manager-lite' ); ?></p>
 
 <?php if ( ! empty( $invites ) ) : ?>
 	<?php foreach ( $invites as $invite ) : ?>

--- a/templates/emails/telegram-channel-invite-links.php
+++ b/templates/emails/telegram-channel-invite-links.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Telegram Channel Invite Links email.
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/emails/telegram-channel-invite-links.php.
+ *
+ * @package WooCommerce\Templates\Emails
+ * @version 1.2.0
+ *
+ * @since 1.2.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/*
+ * @hooked WC_Emails::email_header() Output the email header
+ */
+do_action( 'woocommerce_email_header', $email_heading, $email );
+?>
+
+<p><?php esc_html_e( 'Thank you for your purchase! Below are your private channel invite links:', 'wctlgm-subscriber-manager-lite' ); ?></p>
+
+<?php if ( ! empty( $invites ) ) : ?>
+	<?php foreach ( $invites as $invite ) : ?>
+		<div style="margin-bottom: 15px; padding: 10px; border: 1px solid #e0e0e0; border-radius: 5px;">
+			<span style="font-weight: bold; font-size: 16px;"><?php echo esc_html( $invite['name'] ); ?>:</span><br>
+			<a href="<?php echo esc_url( $invite['invite_link'] ); ?>" style="color: <?php echo esc_attr( $email->get_option( 'link_color', '#96588a' ) ); ?>; text-decoration: none; background-color: #96588a; color: white; padding: 8px 16px; border-radius: 4px; display: inline-block; margin-top: 5px;"><?php esc_html_e( 'Join Channel', 'wctlgm-subscriber-manager-lite' ); ?></a>
+		</div>
+	<?php endforeach; ?>
+<?php endif; ?>
+
+<p><?php esc_html_e( 'These invite links are private and should not be shared with others.', 'wctlgm-subscriber-manager-lite' ); ?></p>
+
+<p><?php esc_html_e( 'If you have any issues or questions, please contact support.', 'wctlgm-subscriber-manager-lite' ); ?></p>
+
+<?php
+/**
+ * Show user-defined additional content - this is set in each email's settings.
+ */
+if ( $additional_content ) {
+	echo wp_kses_post( wpautop( wptexturize( $additional_content ) ) );
+}
+
+/*
+ * @hooked WC_Emails::email_footer() Output the email footer
+ */
+do_action( 'woocommerce_email_footer', $email );

--- a/templates/emails/telegram-channel-invite-links.php
+++ b/templates/emails/telegram-channel-invite-links.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Telegram Channel Invite Links email.
+ * Telegram Channel Invite Links email. Used when the activation flow is disabled.
  *
  * This template can be overridden by copying it to yourtheme/woocommerce/emails/telegram-channel-invite-links.php.
  *
@@ -18,18 +18,18 @@ defined( 'ABSPATH' ) || exit;
 do_action( 'woocommerce_email_header', $email_heading, $email );
 ?>
 
-<p><?php esc_html_e( 'Thank you for your purchase! Below are your private channel invite links:', 'wctlgm-subscriber-manager-lite' ); ?></p>
+<p><?php esc_html_e( 'Thank you for your purchase! Below are your invite links:', 'wctlgm-subscriber-manager-lite' ); ?></p>
 
 <?php if ( ! empty( $invites ) ) : ?>
 	<?php foreach ( $invites as $invite ) : ?>
 		<div style="margin-bottom: 15px; padding: 10px; border: 1px solid #e0e0e0; border-radius: 5px;">
 			<span style="font-weight: bold; font-size: 16px;"><?php echo esc_html( $invite['name'] ); ?>:</span><br>
-			<a href="<?php echo esc_url( $invite['invite_link'] ); ?>" style="color: <?php echo esc_attr( $email->get_option( 'link_color', '#96588a' ) ); ?>; text-decoration: none; background-color: #96588a; color: white; padding: 8px 16px; border-radius: 4px; display: inline-block; margin-top: 5px;"><?php esc_html_e( 'Join Channel', 'wctlgm-subscriber-manager-lite' ); ?></a>
+			<a href="<?php echo esc_url( $invite['invite_link'] ); ?>" style="color: <?php echo esc_attr( $email->get_option( 'link_color', '#96588a' ) ); ?>; text-decoration: underline;"><?php echo esc_url( $invite['invite_link'] ); ?></a>
 		</div>
 	<?php endforeach; ?>
 <?php endif; ?>
 
-<p><?php esc_html_e( 'These invite links are private and should not be shared with others.', 'wctlgm-subscriber-manager-lite' ); ?></p>
+<p><?php esc_html_e( 'These invite links are one-time use only and should not be shared with others.', 'wctlgm-subscriber-manager-lite' ); ?></p>
 
 <p><?php esc_html_e( 'If you have any issues or questions, please contact support.', 'wctlgm-subscriber-manager-lite' ); ?></p>
 

--- a/templates/emails/telegram-channel-invite-links.php
+++ b/templates/emails/telegram-channel-invite-links.php
@@ -5,9 +5,9 @@
  * This template can be overridden by copying it to yourtheme/woocommerce/emails/telegram-channel-invite-links.php.
  *
  * @package WooCommerce\Templates\Emails
- * @version 1.2.0
+ * @version 1.4.0
  *
- * @since 1.2.0
+ * @since 1.4.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/wctlgm-subscriber-manager-lite.php
+++ b/wctlgm-subscriber-manager-lite.php
@@ -5,7 +5,7 @@
  * @version 1.4.0
  * Plugin Name: Subscriber Manager Lite for Telegram
  * Plugin URI: https://github.com/nickpagz/wctlgm-subscriber-manager-lite
- * Description: A plugin to automatically manage Telegram private channel subscribers via WooCommerce.
+ * Description: A plugin to automatically manage Telegram private channel or group subscribers via WooCommerce.
  * Version: 1.4.0
  * Author: Rektification
  * Author URI: https://turtlesignals.com

--- a/wctlgm-subscriber-manager-lite.php
+++ b/wctlgm-subscriber-manager-lite.php
@@ -71,11 +71,23 @@ if ( ! defined( 'WCTLGM_SML_PLUGIN_DIR' ) ) {
 }
 
 /**
+ * Load plugin text domain for translations.
+ */
+function wctlgm_load_textdomain() {
+	load_plugin_textdomain(
+		'wctlgm-subscriber-manager-lite',
+		false,
+		dirname( plugin_basename( __FILE__ ) ) . '/languages'
+	);
+}
+add_action( 'init', 'wctlgm_load_textdomain' );
+
+/**
  * Plugin activation.
  */
 function wctlgm_subscriber_manager_lite_activation() {
 	if ( ! class_exists( 'WooCommerce' ) ) {
-		wp_die( esc_html__( 'Plugin not activated. WooCommerce not found.', 'wctlgm-subscriber-manager-lite' ) );
+		wp_die( 'Plugin not activated. WooCommerce not found.' );
 	}
 }
 

--- a/wctlgm-subscriber-manager-lite.php
+++ b/wctlgm-subscriber-manager-lite.php
@@ -77,8 +77,6 @@ function wctlgm_subscriber_manager_lite_activation() {
 	if ( ! class_exists( 'WooCommerce' ) ) {
 		wp_die( esc_html__( 'Plugin not activated. WooCommerce not found.', 'wctlgm-subscriber-manager-lite' ) );
 	}
-
-	// Migration handled in settings class
 }
 
 register_activation_hook( __FILE__, 'wctlgm_subscriber_manager_lite_activation' );

--- a/wctlgm-subscriber-manager-lite.php
+++ b/wctlgm-subscriber-manager-lite.php
@@ -2,11 +2,11 @@
 
 /**
  * @package Subscriber_Manager_Lite_for_Telegram
- * @version 1.3.0
+ * @version 1.4.0
  * Plugin Name: Subscriber Manager Lite for Telegram
  * Plugin URI: https://github.com/nickpagz/wctlgm-subscriber-manager-lite
  * Description: A plugin to automatically manage Telegram private channel subscribers via WooCommerce.
- * Version: 1.3.0
+ * Version: 1.4.0
  * Author: Rektification
  * Author URI: https://turtlesignals.com
  * License: GPL-2.0-or-later
@@ -78,24 +78,10 @@ function wctlgm_subscriber_manager_lite_activation() {
 		wp_die( esc_html__( 'Plugin not activated. WooCommerce not found.', 'wctlgm-subscriber-manager-lite' ) );
 	}
 
-	// Run upgrade routine on activation - Temp
-	wctlgm_lite_setup_activation_default();
-}
-
-/**
- * Set up the default activation requirement for new installations - Temp
- */
-function wctlgm_lite_setup_activation_default() {
-	// Only run if the option hasn't been explicitly set
-	if ( false === get_option( 'wctlgm_force_activation_flow', false ) ) {
-		update_option( 'wctlgm_force_activation_flow', true );
-	}
+	// Migration handled in settings class
 }
 
 register_activation_hook( __FILE__, 'wctlgm_subscriber_manager_lite_activation' );
-
-// Check for upgrades on every plugin load - TEMP
-add_action( 'plugins_loaded', 'wctlgm_lite_setup_activation_default' );
 
 /**
  * Plugin deactivation.


### PR DESCRIPTION
This PR adds the option to make the activation flow optional.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a setting to skip activation; when disabled, invite links are generated on order processing/completion and emailed, with updated webhook scopes, join validation, logging, and UI tweaks.
> 
> - **Core Behavior**:
>   - Optional activation flow via `wctlgm_require_activation_flow`; when disabled, generate/store per-channel invites (`_channel_invite_<channel_id>`) and skip code activation.
>   - Order processing moved to `woocommerce_order_status_changed`; triggers on `processing`/`completed` and avoids duplicate runs.
> - **Bot/API**:
>   - Webhook `allowed_updates` now dynamic via `get_allowed_updates()` based on activation setting.
>   - Expanded error/info logging across API calls and bot interactions.
>   - Join request validation now per-channel invite meta and supports optional external invites; captures Telegram user ID when activation is disabled.
> - **Emails**:
>   - New customer email `wctlgm_invite_links` with templates (`emails/telegram-channel-invite-links.php` + plain) for the no-activation flow.
>   - Activation email wording updated to “Invite Links.”
> - **Order UX**:
>   - Order details show activation code/info when required; otherwise list invite links.
> - **Admin/Settings UI**:
>   - New setting “Require Activation Step”; migration from legacy option.
>   - Product tab/labels updated (Telegram Access, Channels/Groups).
> - **Misc/Versioning**:
>   - Version bump to `1.4.0` with README changelog.
>   - Removed temporary activation default setup code; general copy tweaks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d8b8dd46661dce5fd9c52d686e88d3adcf636e5e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->